### PR TITLE
Add fixtures data mocks to acceptance tests

### DIFF
--- a/acj/static/test/config/protractor_cucumber.js
+++ b/acj/static/test/config/protractor_cucumber.js
@@ -1,6 +1,6 @@
 exports.config = {
     //seleniumAddress: 'http://localhost:4444/wd/hub',
-	seleniumServerJar: '../../../../node_modules/protractor/selenium/selenium-server-standalone-2.47.1.jar',
+	//seleniumServerJar: '../../../../node_modules/protractor/selenium/selenium-server-standalone-2.47.1.jar',
     specs: ['../features/**/*.feature'],
     framework: 'cucumber',
     cucumberOpts: {

--- a/acj/static/test/config/protractor_saucelab.js
+++ b/acj/static/test/config/protractor_saucelab.js
@@ -13,14 +13,14 @@ exports.config = {
 		'build': process.env.TRAVIS_BUILD_NUMBER,
 		'name': 'acj suite tests',
 		'version': '39',
-		'selenium-version': '2.44.0'
+		'selenium-version': '2.52.0'
 	}, {
 		'browserName': 'firefox',
 		'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
 		'build': process.env.TRAVIS_BUILD_NUMBER,
 		'name': 'acj suite tests',
 		'version': '34',
-		'selenium-version': '2.44.0'
+		'selenium-version': '2.52.0'
 	}],
     cucumberOpts: {
         format: 'pretty'

--- a/acj/static/test/factories/course_factory.js
+++ b/acj/static/test/factories/course_factory.js
@@ -1,0 +1,23 @@
+var objectAssign = require('object-assign');
+
+var courseTemplate = {
+    "id": null,
+    "name": null,
+    "description": null,
+    "available": true,
+    "enable_student_create_questions": false,
+    "enable_student_create_tags": false,
+    "modified": "Sun, 11 Jan 2015 08:44:46 -0000",
+    "created": "Sun, 11 Jan 2015 08:44:46 -0000"
+}
+
+function CourseFactory() {};
+
+CourseFactory.prototype.generateCourse = function (id, parameters) {
+    var newCourse = objectAssign({}, courseTemplate, parameters);
+    newCourse.id = id;
+    
+    return newCourse;
+};
+
+module.exports = CourseFactory;

--- a/acj/static/test/factories/http_backend_mocks.js
+++ b/acj/static/test/factories/http_backend_mocks.js
@@ -1,550 +1,411 @@
-function passThrough($httpBackend) {
-	$httpBackend.whenGET(/.*/).passThrough();
-}
-
-function build(funcs) {
-	var funcStr = "angular.module('httpBackEndMock', ['ngMockE2E'])";
-
-	if (Array.isArray(funcs)) {
-		for (var i = 0; i < funcs.length; i++) {
-			funcStr += "\r.run(" + funcs[i] + ")"
-		}
-	} else {
-		funcStr += "\r.run(" + funcs + ")"
-	}
-
-	funcStr += "\r.run(" + passThrough + ")";
-
-	var funcTyped = Function(funcStr);
-
-	//console.log(funcTyped.toString())
-	return funcTyped;
-}
-
-module.exports.build = function(browser, funcs) {
+module.exports.build = function(browser, storageFixture) {
 	if (process.env.DISABLE_MOCK == 'true') {
 		return;
 	}
 
-	browser.addMockModule('httpBackEndMock', build(funcs));
+	browser.addMockModule('httpBackEndMock', module.exports.httpbackendMock, storageFixture);
 };
 
-module.exports.session = function ($httpBackend, Session, $rootScope) {
-	console.log(Session.isLoggedIn());
-	var authenticated = false;
-	var current_user = 0;
-	var permission_root = {
-		"Courses": {
-			"create": {'global': true},
-			"delete": {'global': true},
-			"edit": {'global': true},
-			"manage": {'global': true},
-			"read": {'global': true}
-		},
-		"PostsForQuestions": {
-			"create": {'global': true},
-			"delete": {'global': true},
-			"edit": {'global': true},
-			"manage": {'global': true},
-			"read": {'global': true}
-		},
-		"Users": {
-			"create": {'global': true},
-			"delete": {'global': true},
-			"edit": {'global': true},
-			"manage": {'global': true},
-			"read": {'global': true}
-		}
-	};
-	var permission_instructor = {
-		"Courses": {
-			"create": {'global': true},
-			"delete": {'global': false, '1': false, '2': false},
-			"edit": {'global': true, '1': true, '2': true},
-			"manage": {'global': false, '1': false, '2': false},
-			"read": {'global': true, '1': true, '2': true}
-		},
-		"PostsForQuestions": {
-			"create": {'global': true, '1': true, '2': true},
-			"delete": {'global': true, '1': true, '2': true},
-			"edit": {'global': true, '1': true, '2': true},
-			"manage": {'global': true, '1': true, '2': true},
-			"read": {'global': true, '1': true, '2': true}
-		},
-		"Users": {
-			"create": {'global': true},
-			"delete": {'global': false},
-			"edit": {'global': true},
-			"manage": {'global': false},
-			"read": {'global': true}
-		}
-	};
-    var permission_student_1 = {
-        "Courses": {
-            "create": {'global': false},
-            "delete": {'global': false, '1': false, '2': false},
-            "edit": {'global': false, '1': false, '2': false},
-            "manage": {'global': false, '1': false, '2': false},
-            "read": {'global': true, '1': true, '2': true}
-        },
-        "PostsForQuestions": {
-            "create": {'global': false, '1': false, '2': false},
-            "delete": {'global': false, '1': false, '2': false},
-            "edit": {'global': false, '1': false, '2': false},
-            "manage": {'global': false, '1': false, '2': false},
-            "read": {'global': true, '1': true, '2': true}
-        },
-        "Users": {
-            "create": {'global': false},
-            "delete": {'global': false},
-            "edit": {'global': true},
-            "manage": {'global': false},
-            "read": {'global': true}
-        }
-    }
-    var permission_student_2 = {
-        "Courses": {
-            "create": {'global': false},
-            "delete": {'global': false},
-            "edit": {'global': false},
-            "manage": {'global': false},
-            "read": {'global': true}
-        },
-        "PostsForQuestions": {
-            "create": {'global': false},
-            "delete": {'global': false},
-            "edit": {'global': false},
-            "manage": {'global': false},
-            "read": {'global': true}
-        },
-        "Users": {
-            "create": {'global': false},
-            "delete": {'global': false},
-            "edit": {'global': true},
-            "manage": {'global': false},
-            "read": {'global': true}
-        }
-    }
-
-	var users = {
-		'root':  {
-			"userid": 1,
-			"permissions": permission_root
-		},
-		'instructor1': {
-			"userid": 2,
-			"permissions": permission_instructor
-		},
-		'student1': {
-			"userid": 3,
-			"permissions": permission_student_1
-		},
-		'student2': {
-			"userid": 4,
-			"permissions": permission_student_2
-		}
-	};
-
-	var sessions = {
-		'root': {
-			"id": 1,
-			"permissions": permission_root
-		},
-		'instructor1': {
-			"id": 2,
-			"permissions": permission_instructor
-		},
-		'student1': {
-			"id": 3,
-			"permissions": permission_student_1
-		},
-		'student2': {
-			"id": 4,
-			"permissions": permission_student_2
-		}
-	};
-    
-    var usertypes = {
-		'root': [
-            { "id": 1, "name": "Student" }, 
-            { "id": 2, "name": "Instructor" }, 
-            { "id": 3, "name": "System Administrator"  }
-        ],
-		'instructor1': [
-            { "id": 1, "name": "Student" }, 
-            { "id": 2, "name": "Instructor" }
-        ],
-		'student1': [
-            { "id": 1, "name": "Student" }, 
-            { "id": 2, "name": "Instructor" }
-        ],
-		'student2': [
-            { "id": 1, "name": "Student" }, 
-            { "id": 2, "name": "Instructor" }
-        ]
-    }
-
-
-	$httpBackend.whenGET('/api/session').respond(function(method, url, data, headers) {
-		return authenticated ? [200, sessions[current_user], {}] : [401, {}, {}];
-	});
-
-	$httpBackend.whenGET('/api/session/permission').respond(function(method, url, data, headers) {
-		var username = undefined;
-		Session.getUser().then(function(user) {
-			username =user.username;
-		});
-		// Propagate getUser() promise resolution to 'then' functions using $apply().
-		$rootScope.$apply();
-
-		return [200, users[username].permissions, {}];
-	});
-
-	$httpBackend.whenGET('/api/usertypes').respond(function(method, url, data, headers) {
-		var username = undefined;
-		Session.getUser().then(function(user) {
-			username =user.username;
-		});
-		// Propagate getUser() promise resolution to 'then' functions using $apply().
-		$rootScope.$apply();
+module.exports.httpbackendMock = function(storageFixture) {
+    angular.module('httpBackEndMock', ['ngMockE2E'])
+    .run(function($httpBackend) {
+        var authenticated = false;
         
-		return [200, usertypes[username], {}];
-	});
-    
-    // get edit button
-	$httpBackend.whenGET(/^\/api\/users\/\d+\/edit$/).respond(function(method, url, data, headers) {
-		var editId = url.split('/')[3];
+        var default_criteria = {
+            "id": 1,
+            "users_id": 1,
+            "name": "Which is better?",
+            "description": "<p>Choose the response that you think is the better of the two.</p>",
+            "default": true,
+            "judged": false,
+            "created": "Sun, 11 Jan 2015 07:45:31 -0000",
+            "modified": "Sun, 11 Jan 2015 07:45:31 -0000"
+        };
         
-        var username = undefined;
-		Session.getUser().then(function(user) {
-			username = user.username;
-		});
-		// Propagate getUser() promise resolution to 'then' functions using $apply().
-		$rootScope.$apply();
-        
-        // Edit button is availble for: yourself, system admins, and members of an instructor's class
-        var available = editId == users[username].userid;
-        switch (username) {
-            case 'root': available = true; break;
-            case 'instructor1': available = (editId == 3); break;
+        var storage = {
+            loginDetails: { id: null, username: null, password: null },
+            session: {},
+            users: [],
+            courses: [],
+            // userId -> [ { courseId, roleId} ]
+            users_and_courses: {},
+            // courseId -> [criteriaId]
+            course_criteria: {},
+            questions: [],
+            // courseId -> [questionId]
+            course_questions: {},
+            // questionId -> [criteriaId]
+            question_criteria: {},
+            criteria: [default_criteria],
+            selfEvalTypes: [
+                { "id": 1, "name": "No Comparison with Another Answer" }
+            ],
+            userTypes: [
+                { "id": 1, "name": "Student" }, 
+                { "id": 2, "name": "Instructor" }
+            ],
+            courseroles: [
+                { "id": 2, "name": "Instructor" }, 
+                { "id": 3, "name": "Teaching Assistant" }, 
+                { "id": 4, "name": "Student" }
+            ]
         }
         
-		return [200, {"available": available}, {}];
-	});
-    
-	$httpBackend.whenPOST('/api/login').respond(function(method, url, data, headers) {
-		authenticated = true;
-		current_user = angular.fromJson(data).username;
-		return [200, users[current_user], {}];
-	});
-	$httpBackend.whenDELETE('/api/logout').respond(function(method, url, data, headers) {
-	    authenticated = false;
-	    return [202, {}, {}];
-	});
-};
-
-module.exports.user = function($httpBackend) {
-	var users = [
-		{},
-		{ // root
-			"avatar": "63a9f0ea7bb98050796b649e85481845",
-			"created": "Sat, 27 Dec 2014 20:13:11 -0000",
-			"displayname": "root",
-			"email": null,
-			"firstname": "JaNy",
-			"fullname": "JaNy bwsV",
-			"id": 1,
-			"lastname": "bwsV",
-			"lastonline": "Sun, 11 Jan 2015 02:55:59 -0000",
-			"modified": "Sun, 11 Jan 2015 02:55:59 -0000",
-			"student_no": null,
-            "system_role": "System Administrator", 
-			"username": "root",
-			"usertypeforsystem": {
-				"id": 3,
-				"name": "System Administrator"
-			},
-			"usertypesforsystem_id": 3
-		},
-		{ // instructor1
-			"avatar": "b47d5e296b954b96c12fe3b5ced166b4",
-			"created": "Sun, 11 Jan 2015 07:59:17 -0000",
-			"displayname": "First Instructor",
-			"email": "first.instructor@exmple.com",
-			"firstname": "First",
-			"fullname": "First Instructor",
-			"id": 2,
-			"lastname": "Instructor",
-			"lastonline": "Sun, 11 Jan 2015 08:25:08 -0000",
-			"modified": "Sun, 11 Jan 2015 08:25:08 -0000",
-			"student_no": null,
-            "system_role": "Instructor", 
-			"username": "instructor1",
-			"usertypeforsystem": {
-				"id": 2,
-				"name": "Instructor"
-			},
-			"usertypesforsystem_id": 2
-		},
-		{ // student1
-            "avatar": "8ddf878039b70767c4a5bcf4f0c4f65e",
-            "created": "Sun, 11 Jan 2015 07:59:17 -0000",
-            "displayname": "First Student",
-            "email": "first.student@exmple.com",
-            "firstname": "First",
-            "fullname": "First Student",
-            "id": 3,
-            "lastname": "Student",
-            "lastonline": "Sun, 11 Jan 2015 08:25:08 -0000",
-            "modified": "Sun, 11 Jan 2015 08:25:08 -0000",
-            "student_no": null,
-            "system_role": "Student", 
-            "username": "student1",
-            "usertypeforsystem": {
-                "id": 1,
-                "name": "Student"
-            },
-            "usertypesforsystem_id": 1
-		},
-		{ // student2
-            "avatar": "8ddf878039b70767c4a5bcf4f0c4f65e",
-            "created": "Sun, 11 Jan 2015 07:59:17 -0000",
-            "displayname": "Second Student",
-            "email": "second.student@exmple.com",
-            "firstname": "Second",
-            "fullname": "Second Student",
-            "id": 4,
-            "lastname": "Student",
-            "lastonline": "Sun, 11 Jan 2015 08:25:08 -0000",
-            "modified": "Sun, 11 Jan 2015 08:25:08 -0000",
-            "student_no": null,
-            "system_role": "Student", 
-            "username": "student2",
-            "usertypeforsystem": {
-                "id": 1,
-                "name": "Student"
-            },
-            "usertypesforsystem_id": 1
-		}
-    ];
+        // add fixture data to storage
+        if (storageFixture) {
+            storage = angular.merge({}, storage, storageFixture);
+        }
         
-	$httpBackend.whenPOST('/api/users').respond({
-        "avatar": "8ddf878039b70767c4a5bcf4f0c4f65e", 
-        "created": "Thu, 14 Apr 2016 19:45:33 -0000", 
-        "displayname": "Second Student", 
-        "id": 4, 
-        "lastonline": null
+        // Start Session
+        
+        // get current session
+        $httpBackend.whenGET('/api/session').respond(function(method, url, data, headers) {
+            return authenticated ? [200, storage.session, {}] : [401, {}, {}];
+        });
+        
+        // get current session permissions
+        $httpBackend.whenGET('/api/session/permission').respond(function(method, url, data, headers) {
+            return authenticated ? [200, storage.session.permissions, {}] : [401, {}, {}];
+        });
+        
+        // login 
+        $httpBackend.whenPOST('/api/login').respond(function(method, url, data, headers) {
+            authenticated = true;
+            var currentUser = angular.copy(storage.users[storage.loginDetails.id-1]);
+            return [200, currentUser, {}];
+        });
+        
+        // logout
+        $httpBackend.whenDELETE('/api/logout').respond(function(method, url, data, headers) {
+            authenticated = false;
+            return [202, {}, {}];
+        });
+        // End Session
+        
+        
+        
+        // Start User
+        
+        // get user types
+        $httpBackend.whenGET('/api/usertypes').respond(storage.userTypes);
+        
+        // get user by id
+        $httpBackend.whenGET(/^\/api\/users\/\d+$/).respond(function(method, url, data, headers) {
+            var id = url.split('/').pop();
+            console.log(storage.users[id-1]);
+            return [200, storage.users[id-1], {}];
+        });
+        
+        // create user
+        $httpBackend.whenPOST('/api/users').respond(function(method, url, data, headers) {
+            data = JSON.parse(data);
+            var newUser = {
+                "id": storage.users.length + 1,
+                "username": null,
+                "displayname": null,
+                "email": null,
+                "firstname": null,
+                "fullname": null,
+                "lastname": null,
+                "student_no": null,
+                "avatar": "63a9f0ea7bb98050796b649e85481845",
+                "created": "Sat, 27 Dec 2014 20:13:11 -0000",
+                "modified": "Sun, 11 Jan 2015 02:55:59 -0000",
+                "lastonline": "Sun, 11 Jan 2015 02:55:59 -0000",
+                "usertypeforsystem": {
+                    "id": null,
+                    "name": null
+                },
+                "system_role": null,
+                "usertypesforsystem_id": null
+            };
+            
+            newUser = angular.merge({}, newUser, data);
+            newUser.fullname = newUser.firstname + " " + newUser.lastname; 
+            newUser.usertypeforsystem.id = newUser.usertypesforsystem_id; 
+            
+            var userType = "";
+            switch (newUser.usertypesforsystem_id) {
+                case 3: userType = "System Administrator"; break;
+                case 2: userType = "Instructor"; break;
+                case 1: userType = "Student"; break;
+            }
+            newUser.system_role = userType;
+            newUser.usertypeforsystem.name = userType;
+            
+            storage.users.push(newUser);
+            
+            var returnData = {
+                id: newUser.id,
+                displayname: newUser.displayname,
+                avatar: newUser.avatar,
+                created: newUser.created,
+                lastonline: newUser.lastonline
+            }
+            
+            return [200, returnData, {}]
+        });
+        
+        // get edit button availability
+        $httpBackend.whenGET(/\/api\/users\/\d+\/edit$/).respond(function(method, url, data, headers) {
+            var editId = url.replace('/edit', '').split('/').pop();
+            var currentUser = angular.copy(storage.users[storage.loginDetails.id-1]);
+            
+            var available = false;
+            // admins can edit anyone
+            if (currentUser.usertypesforsystem_id == 3) {
+                available = true;
+                
+            // anyone can edit themselves
+            } else if (currentUser.id == editId) {
+                available = true;
+            
+            // teachers can edit users in their class
+            } else if (currentUser.usertypesforsystem_id == 2) {
+                
+                // if both current user and edit user have courses
+                if (storage.users_and_courses[currentUser.id] && storage.users_and_courses[editId]) {
+                    
+                    // check courses current user is instructor of
+                    angular.forEach(storage.users_and_courses[currentUser.id], function(course_and_role) {
+                        if (course_and_role.role == 2) {
+                            var courseId = course_and_role.courseId;
+                            
+                            // check if edit user in course
+                            angular.forEach(storage.users_and_courses[currentUser.id], function(course_and_role) {
+                                // if edit user in course
+                                if (course_and_role.courseId == courseId) {
+                                    available = true;
+                                }
+                            });
+                        }
+                    });
+                }
+            }
+            
+            return [200, { "available": available }, {}];
+        });
+        
+        // End User
+        
+        
+        // Start Courses
+        
+        // get course roles 
+        $httpBackend.whenGET('/api/courseroles').respond(storage.courseroles);
+        
+        // get current user courses
+        $httpBackend.whenGET(/\/api\/users\/\d+\/courses$/).respond({
+            "objects": storage.courses
+        });
+        
+        /*
+        TODO check if needed
+        $httpBackend.whenGET(/\/api\/courses\/\d+\/name$/).respond(function(method, url, data, headers) {
+            var id = url.replace('/name', '').split('/').pop();
+            return [200, {'course_name': courses.objects[id-1].name}, {}];
+        });
+        */
+        
+        // create new course
+        $httpBackend.whenPOST('/api/courses').respond(function(method, url, data, headers) {
+            data = JSON.parse(data);
+            
+            var id = storage.courses.length + 1;
+            
+            var newCourse = {
+                "id": id,
+                "name": data.name,
+                "description": data.description,
+                "available": true,
+                "enable_student_create_questions": false,
+                "enable_student_create_tags": false,
+                "modified": "Sun, 11 Jan 2015 08:44:46 -0000",
+                "created": "Sun, 11 Jan 2015 08:44:46 -0000"
+            }
+            
+            storage.courses.push(newCourse);
+            
+            // setup course criteria
+            storage.course_criteria[id] = [];
+            angular.forEach(data.criteria, function(criteria, key) {
+                storage.course_criteria[id].push(criteria.id);
+            });
+            
+            return [200, newCourse, {}];
+        });
+        
+        // get course by id
+        $httpBackend.whenGET(/\/api\/courses\/\d+$/).respond(function(method, url, data, headers) {
+            var id = url.split('/').pop();
+            return [200, storage.courses[id-1], {}];
+        });
+        
+        // get course criteria by course id
+        $httpBackend.whenGET(/\/api\/courses\/\d+\/criteria$/).respond(function(method, url, data, headers){
+            var id = url.replace('/criteria', '').split('/').pop();
+            
+            var criteriaList = [];
+            
+            console.log(criteriaList);
+            
+            if (storage.course_criteria[id]) {
+                angular.forEach(storage.course_criteria[id], function(criteriaId) {
+                    console.log(criteriaId, storage.criteria[criteriaId-1]);
+                    criteriaList.push(storage.criteria[criteriaId-1]);
+                });
+            }
+            
+            console.log(criteriaList);
+            
+            return [200, { 'objects': criteriaList }, {}];
+        });
+        
+        
+        $httpBackend.whenGET(/\/api\/courses\/\d+\/judgements\/availpair$/).respond({
+            "availPairsLogic": {}
+        });
+        $httpBackend.whenGET(/\/api\/courses\/\d+\/judgements\/count$/).respond({
+            "judgements": 0
+        });
+        $httpBackend.whenGET(/\/api\/courses\/\d+\/answers\/answered$/).respond({
+            "answered": {}
+        });
+        
+        /*
+        TODO: check usage
+        $httpBackend.whenPOST(/\/api\/courses\/\d+\/criteria\/\d$/).respond(function(method, url, data, headers) {
+        });
+        */
+        
+        /*
+        TODO: check usage
+        $httpBackend.whenGET('/api/criteria/default').respond(default_criteria);
+        */
+        
+        $httpBackend.whenGET('/api/criteria').respond(storage.criteria);
+
+        $httpBackend.whenGET(/\/api\/selfeval\/courses\/\d+\/questions$/).respond({
+            "replies": {}
+        });
+        
+        
+        // End Courses
+        
+        
+        
+        // Start Questions
+        
+        $httpBackend.whenGET('/api/selfevaltypes').respond({
+            'types': storage.selfEvalTypes
+        });
+        
+        $httpBackend.whenGET(/\/api\/courses\/\d+\/questions$/).respond(function(method, url, data, headers) {
+            var id = url.replace('/questions', '').split('/').pop();
+            
+            var questionList = [];
+            
+            if (storage.course_questions[id]) {
+                angular.forEach(storage.course_questions[id], function(questionId) {
+                    questionList.push(storage.questions[questionId-1]);
+                });
+            }
+            
+            return [200, { 'questions': questionList }, {}]
+        });
+
+        $httpBackend.whenPOST(/\/api\/courses\/\d+\/questions$/).respond(function(method, url, data, headers) {
+            data = JSON.parse(data);
+            
+            var courseId = url.replace('/questions', '').split('/').pop();
+            var currentUser = angular.copy(storage.users[storage.loginDetails.id-1]);
+            
+            var newQuestion = {
+                "id": null, 
+                "title": null, 
+                "num_judgement_req": null, 
+                "answer_end": null, 
+                "answer_start": null, 
+                "can_reply": null, 
+                "judge_end": null, 
+                "judge_start": null, 
+                "after_judging": false, 
+                "answer_period": false, 
+                "answers_count": 0, 
+                "available": false, 
+                "comments_count": 0, 
+                "criteria": [], 
+                "evaluation_count": 0, 
+                "judged": false, 
+                "judging_period": false, 
+                "modified": "Wed, 20 Apr 2016 21:50:31 -0000", 
+                "selfevaltype_id": 0,
+                "post": {
+                    "id": null, 
+                    "content": null, 
+                    "files": [], 
+                    "user": angular.copy(currentUser),
+                    "created": "Wed, 20 Apr 2016 21:50:31 -0000", 
+                    "modified": "Wed, 20 Apr 2016 21:50:31 -0000"
+                }
+            }
+            newQuestion = angular.merge(newQuestion, data);
+            newQuestion.id = storage.questions.length + 1;
+            
+            storage.questions.push(newQuestion);
+            
+            if (!storage.course_questions[courseId]) {
+                storage.course_questions[courseId] = [];
+            }
+            storage.course_questions[courseId].push(newQuestion.id)
+            
+            return [200, newQuestion, {}]
+        });
+
+        $httpBackend.whenPOST(/\/api\/courses\/\d+\/questions\/\d+\/criteria\/\d+$/).respond(function(method, url, data, headers) {
+            data = JSON.parse(data);
+            
+            var courseId = url.split('/')[3];
+            var questionId = url.split('/')[5];
+            var criteriaId = url.split('/').pop();
+            
+            if (!storage.question_criteria[questionId]) {
+                storage.question_criteria[questionId] = [];
+            }
+            var active = false,
+                activeIndex = null;
+            angular.forEach(storage.question_criteria[questionId], function(activeCriteriaId, index) {
+                if (activeCriteriaId == criteriaId) {
+                    active = true;
+                    activeIndex = index;
+                }
+            });
+            
+            if (active) {
+                // remvoe criteria
+                storage.question_criteria[questionId] = storage.question_criteria[questionId].splice(activeIndex, 1);
+            } else {
+                // add criteria
+                storage.question_criteria[questionId].push(criteriaId);
+            }
+            
+            var criteria = storage.criteria[criteriaId-1];
+            var returnData = {
+                'active': !active,
+                'criterion': criteria
+            }
+            
+            return [200, returnData, {}]
+        });
+        
+        $httpBackend.whenPOST(/\/api\/courses\/\d+\/questions\/\d+\/criteria\/\d+$/).respond({
+            'active': true,
+            'criterion': default_criteria
+        });
+        
+        // End Questions
+    })
+    .run(function($httpBackend) {
+        $httpBackend.whenGET(/.*/).passThrough();
     });
-
-	$httpBackend.whenGET(/^\/api\/users\/\d+$/).respond(function(method, url, data, headers) {
-		var id = url.split('/').pop();
-		return [200, users[id], {}];
-	});
-};
-
-
-module.exports.course = function($httpBackend) {
-	var default_criteria = {
-		"created": "Sun, 11 Jan 2015 07:45:31 -0000",
-		"default": true,
-		"description": "<p>Choose the response that you think is the better of the two.</p>",
-		"id": 1,
-		"judged": false,
-		"modified": "Sun, 11 Jan 2015 07:45:31 -0000",
-		"name": "Which is better?",
-		"users_id": 1
-	};
-
-	var criteria = {
-		"criteria": [default_criteria]
-	};
-
-	var course1 = {
-		"criteriaandcourses": [
-			{
-				"active": true,
-				"courses_id": 1,
-				"criterion": default_criteria,
-				"id": 1,
-				"inQuestion": false
-			}
-		],
-		"description": null,
-		"id": 1,
-		"name": "Test Course 1"
-	};
-
-	var course2 = {
-		"available": true,
-		"created": "Sun, 11 Jan 2015 08:44:46 -0000",
-		"criteriaandcourses": [
-			{
-				"active": true,
-				"courses_id": 2,
-				"criterion": default_criteria,
-				"id": 2,
-				"inQuestion": false
-			}
-		],
-		"description": "<p>This is the description for Test Course 2<p>",
-		"enable_student_create_questions": false,
-		"enable_student_create_tags": false,
-		"id": 2,
-		"modified": "Sun, 11 Jan 2015 08:44:46 -0000",
-		"name": "Test Course 2"
-	};
-
-	var post1 = {
-		"content": "",
-		"created": "Fri, 06 Feb 2015 22:12:59 -0000",
-		"files": [],
-		'id': 1,
-		'modified': "Fri, 06 Feb 2015 22:12:59 -0000",
-		'user': {
-			"avatar": "b47d5e296b954b96c12fe3b5ced166b4",
-			"created": "Sun, 11 Jan 2015 07:59:17 -0000",
-			"displayname": "First Instructor",
-			"id": 2,
-			"lastonline": "Sun, 11 Jan 2015 08:25:08 -0000",
-		}
-	};
-
-	var course1question = {
-		"after_judging": false,
-		"answer_end": "Sun, 15 Feb 2015 07:59:00 -0000",
-		"answer_period": false,
-		"answer_start": "Sat, 07 Feb 2015 08:00:00 -0000",
-		"answers": [],
-		"answers_count": 0,
-		"available": false,
-		"can_reply": true,
-		"comments_count": 0,
-		"criteria": [],
-		"evaluation_count": 0,
-		"id": 1,
-		"judge_end": null,
-		"judge_start": null,
-		"judged": false,
-		"judging_period": false,
-		"modified": "Fri, 06 Feb 2015 22:12:59 -0000",
-		"num_judgement_req": 3,
-		"post": post1,
-		"selfevaltype_id": 0,
-		"title": "Test Question"
-	};
-
-	var questions = [
-		[course1question],
-		[]
-	];
-
-	var courses = {
-		"objects": [course1, course2]
-	};
-
-	var courseroles = [
-        { "id": 2, "name": "Instructor" }, 
-        { "id": 3, "name": "Teaching Assistant" }, 
-        { "id": 4, "name": "Student" }
-    ];
-    
-	$httpBackend.whenGET('/api/courseroles').respond(courseroles);
-
-	$httpBackend.whenGET(/\/api\/users\/\d+\/courses$/).respond(courses);
-	$httpBackend.whenGET(/\/api\/courses\/\d+\/name$/).respond(function(method, url, data, headers) {
-		var id = url.replace('/name', '').split('/').pop();
-		return [200, {'course_name': courses.objects[id-1].name}, {}];
-	});
-	$httpBackend.whenPOST('/api/courses').respond(course2);
-	$httpBackend.whenGET(/\/api\/courses\/\d+$/).respond(function(method, url, data, headers) {
-		var id = url.split('/').pop();
-		return [200, courses.objects[id-1], {}];
-	});
-
-	$httpBackend.whenGET(/\/api\/courses\/\d+\/criteria$/).respond(function(method, url, data, headers){
-		var id = url.replace('/criteria', '').split('/').pop();
-		return [200, {'objects': courses.objects[id-1].criteriaandcourses}, {}];
-	});
-	$httpBackend.whenGET(/\/api\/courses\/\d+\/judgements\/availpair$/).respond({
-		"availPairsLogic": {}
-	});
-	$httpBackend.whenGET(/\/api\/courses\/\d+\/questions$/).respond(function(method, url, data, headers) {
-		var id = url.replace('/questions', '').split('/').pop();
-		return [200, {'questions': questions[id-1]}, {}]
-	});
-	$httpBackend.whenGET(/\/api\/courses\/\d+\/judgements\/count$/).respond({
-		"judgements": 0
-	});
-	$httpBackend.whenGET(/\/api\/courses\/\d+\/answers\/answered$/).respond({
-		"answered": {}
-	});
-
-	$httpBackend.whenPOST('/api/courses/2/criteria/1').respond({
-		"criterion": {
-			"active": true,
-			"courses_id": 2,
-			"criterion": default_criteria,
-			"id": 2,
-			"inQuestion": false
-		}
-	});
-	$httpBackend.whenPOST(/\/api\/courses\/\d+\/questions\/\d+\/criteria\/\d+$/).respond({
-		'active': true,
-		'criterion': default_criteria
-	});
-	$httpBackend.whenGET('/api/criteria/default').respond(default_criteria);
-	$httpBackend.whenGET('/api/criteria').respond(criteria);
-
-	$httpBackend.whenGET(/\/api\/selfeval\/courses\/\d+\/questions$/).respond({
-		"replies": {}
-	});
-};
-
-module.exports.question = function($httpBackend) {
-	var selfeval1 = {
-		'id': 1,
-		'name': "No Comparison with Another Answer"
-	};
-	var post1 = {
-		"content": "",
-		"created": "Fri, 06 Feb 2015 22:12:59 -0000",
-		"files": [],
-		'id': 1,
-		'modified': "Fri, 06 Feb 2015 22:12:59 -0000",
-		'user': {
-			"avatar": "b47d5e296b954b96c12fe3b5ced166b4",
-			"created": "Sun, 11 Jan 2015 07:59:17 -0000",
-			"displayname": "First Instructor",
-			"id": 2,
-			"lastonline": "Sun, 11 Jan 2015 08:25:08 -0000",
-		}
-	};
-
-	$httpBackend.whenGET('/api/selfevaltypes').respond({
-		'types': [selfeval1]
-	});
-
-	$httpBackend.whenPOST(/\/api\/courses\/\d+\/questions$/).respond({
-		"after_judging": false,
-		"answer_end": "Sun, 15 Feb 2015 07:59:00 -0000",
-		"answer_period": false,
-		"answer_start": "Sat, 07 Feb 2015 08:00:00 -0000",
-		"answers": [],
-		"answers_count": 0,
-		"available": false,
-		"can_reply": true,
-		"comments_count": 0,
-		"criteria": [],
-		"evaluation_count": 0,
-		"id": 1,
-		"judge_end": null,
-		"judge_start": null,
-		"judged": false,
-		"judging_period": false,
-		"modified": "Fri, 06 Feb 2015 22:12:59 -0000",
-		"num_judgement_req": 3,
-		"post": post1,
-		"selfevaltype_id": 0,
-		"title": "Test Question"
-	});
 };

--- a/acj/static/test/factories/question_factory.js
+++ b/acj/static/test/factories/question_factory.js
@@ -1,0 +1,56 @@
+var objectAssign = require('object-assign');
+
+var questionTemplate = {
+    "id": null, 
+    "title": "asd asdas dasdasd",
+    "criteria": [], 
+    "name": null,
+    "selfevaltype_id": 0, 
+    "comments_count": 0, 
+    "evaluation_count": 0, 
+    "answers_count": 0,
+    "answer_period": false, 
+    "answer_end": "Thu, 28 Apr 2016 06:59:00 -0000", 
+    "answer_start": "Wed, 20 Apr 2016 07:00:00 -0000", 
+    "available": false, 
+    "can_reply": true, 
+    "num_judgement_req": 3, 
+    "judge_end": null, 
+    "judge_start": null, 
+    "judged": false, 
+    "judging_period": false, 
+    "after_judging": false, 
+    "modified": "Tue, 19 Apr 2016 20:06:43 -0000", 
+    "post": {}, 
+}
+
+var postTempalte = {
+    'id': null,
+    "content": "",
+    "files": [],
+    'user': {},
+    "created": "Fri, 06 Feb 2015 22:12:59 -0000",
+    'modified': "Fri, 06 Feb 2015 22:12:59 -0000",
+}
+
+var userTempalte = {
+    "id": null,
+    "displayname": null,
+    "avatar": "b47d5e296b954b96c12fe3b5ced166b4",
+    "created": "Sun, 11 Jan 2015 07:59:17 -0000",
+    "lastonline": "Sun, 11 Jan 2015 08:25:08 -0000",
+}
+
+function QuestionFactory() {};
+
+QuestionFactory.prototype.generateQuestion = function (id, user, parameters) {
+    var newQuestion = objectAssign({}, questionTemplate, parameters);
+    newQuestion.id = id;
+    
+    newQuestion.post = objectAssign({}, postTempalte, parameters.post);
+    newQuestion.post.user = objectAssign({}, user);
+    
+    return newQuestion;
+};
+
+module.exports = QuestionFactory;

--- a/acj/static/test/factories/session_factory.js
+++ b/acj/static/test/factories/session_factory.js
@@ -1,0 +1,112 @@
+var objectAssign = require('object-assign');
+
+var permission_admin = {
+    "Courses": {
+        "create": {'global': true},
+        "delete": {'global': true},
+        "edit": {'global': true},
+        "manage": {'global': true},
+        "read": {'global': true}
+    },
+    "PostsForQuestions": {
+        "create": {'global': true},
+        "delete": {'global': true},
+        "edit": {'global': true},
+        "manage": {'global': true},
+        "read": {'global': true}
+    },
+    "Users": {
+        "create": {'global': true},
+        "delete": {'global': true},
+        "edit": {'global': true},
+        "manage": {'global': true},
+        "read": {'global': true}
+    }
+};
+
+var permission_instructor = {
+    "Courses": {
+        "create": {'global': true},
+        "delete": {'global': false},
+        "edit": {'global': true},
+        "manage": {'global': false},
+        "read": {'global': true}
+    },
+    "PostsForQuestions": {
+        "create": {'global': true},
+        "delete": {'global': true},
+        "edit": {'global': true},
+        "manage": {'global': true},
+        "read": {'global': true}
+    },
+    "Users": {
+        "create": {'global': true},
+        "delete": {'global': false},
+        "edit": {'global': true},
+        "manage": {'global': false},
+        "read": {'global': true}
+    }
+};
+
+
+var permission_student = {
+    "Courses": {
+        "create": {'global': false},
+        "delete": {'global': false},
+        "edit": {'global': false},
+        "manage": {'global': false},
+        "read": {'global': true}
+    },
+    "PostsForQuestions": {
+        "create": {'global': false},
+        "delete": {'global': false},
+        "edit": {'global': false},
+        "manage": {'global': false},
+        "read": {'global': true}
+    },
+    "Users": {
+        "create": {'global': false},
+        "delete": {'global': false},
+        "edit": {'global': true},
+        "manage": {'global': false},
+        "read": {'global': true}
+    }
+}
+
+var permissionTemplates = {
+    'System Administrator' : {
+        'id': null,
+        'permissions': permission_admin
+    },
+    'Instructor' : {
+        'id': null,
+        'permissions': permission_instructor
+    },
+    'Student' : {
+        'id': null,
+        'permissions': permission_student
+    }
+}
+
+function SessionFactory() {};
+
+
+SessionFactory.prototype.generateSession = function (userId, type, additionalPermissions) {
+    var newSession = objectAssign({}, permissionTemplates[type]);
+    newSession.id = userId;
+    
+    if(additionalPermissions) {
+        for(var domain in additionalPermissions) {
+            for(var action in additionalPermissions[domain]) {
+                var permissionBase = newSession.permissions[domain][action];
+                var permissionExtend = additionalPermissions[domain][action];
+                newSession.permissions[domain][action] = objectAssign({}, permissionBase, permissionExtend);
+            }
+        }
+    }
+    
+    return newSession;
+};
+
+
+module.exports = SessionFactory;

--- a/acj/static/test/factories/user_factory.js
+++ b/acj/static/test/factories/user_factory.js
@@ -1,19 +1,55 @@
-var users = {
-    'admin': { username: 'root', password: 'password' },
-    'instructor1': { username: 'instructor1', password: 'password' },
-    'student1': { username: 'student1', password: 'password' },
-    'student2': { username: 'student2', password: 'password' }
-};
+var objectAssign = require('object-assign');
 
-function UserFactory() {
+var userTempalte = {
+    "id": null,
+    "username": null,
+    "displayname": null,
+    "email": null,
+    "firstname": null,
+    "fullname": null,
+    "lastname": null,
+    "student_no": null,
+    "avatar": "63a9f0ea7bb98050796b649e85481845",
+    "created": "Sat, 27 Dec 2014 20:13:11 -0000",
+    "modified": "Sun, 11 Jan 2015 02:55:59 -0000",
+    "lastonline": "Sun, 11 Jan 2015 02:55:59 -0000",
+    "system_role": null, 
+    "usertypeforsystemTemplate": null,
+    "usertypesforsystem_id": null
 }
 
-UserFactory.prototype.getUser = function (username) {
-    if (!users.hasOwnProperty(username)) {
-        throw 'Test user "' + username + '" is not defined! Please define it in user_factory.js.';
-    }
+var usertypeforsystemTemplate = {
+    "id": null,
+    "name": null
+};
 
-    return users[username];
+function UserFactory() {};
+
+
+UserFactory.prototype.generateUser = function (id, userType, parameters) {
+    var newUser = objectAssign({}, userTempalte, parameters);
+    newUser.id = id;
+    newUser.system_role = userType;
+    
+    newUser.usertypeforsystem = objectAssign({}, usertypeforsystemTemplate);
+    newUser.usertypeforsystem.name = userType;
+    
+    switch (userType) {
+        case "System Administrator":
+            newUser.usertypesforsystem_id = 3;
+            newUser.usertypeforsystem.id = 3;
+            break;
+        case "Instructor":
+            newUser.usertypesforsystem_id = 2;
+            newUser.usertypeforsystem.id = 2;
+            break;
+        case "Student":
+            newUser.usertypesforsystem_id = 1;
+            newUser.usertypeforsystem.id = 1;
+            break;
+    }
+    
+    return newUser;
 };
 
 module.exports = UserFactory;

--- a/acj/static/test/features/create_course.feature
+++ b/acj/static/test/features/create_course.feature
@@ -2,19 +2,19 @@ Feature: Create Course
   As user, I want to create courses
 
   Scenario: Loading add course page by Add Course button as admin
-    Given I'm "admin"
+    Given I'm a System Administrator
     And I'm on "home" page
     When I select "Add Course" button
     Then "Add Course" page should load
 
   Scenario: Loading add course page by add a course button as instructor
-    Given I'm "instructor1"
+    Given I'm an Instructor
     And I'm on "home" page
     When I select "Add Course" button
     Then "Add Course" page should load
 
   Scenario: Creating a course as instructor
-    Given I'm "instructor1"
+    Given I'm an Instructor
     And I'm on "create course" page
     And I toggle the "Add a course description:" checkbox
     And I fill in rich text "This is the description for Test Course 2" for "cke_courseDescription"

--- a/acj/static/test/features/create_question.feature
+++ b/acj/static/test/features/create_question.feature
@@ -2,19 +2,19 @@ Feature: Create Question
   As user, I want to create questions
 
   Scenario: Loading add question page by Add Assignment button as admin
-    Given I'm "admin"
+    Given I'm a System Administrator with courses
     And I'm on "course" page for course with id "1"
     When I select "Add Assignment" button
     Then "Add Assignment" page should load
 
   Scenario: Loading add question page by Add Assignment button as instructor
-    Given I'm "instructor1"
+    Given I'm an Instructor with courses
     And I'm on "course" page for course with id "1"
     When I select "Add Assignment" button
     Then "Add Assignment" page should load
 
   Scenario: Creating a question as instructor
-    Given I'm "instructor1"
+    Given I'm an Instructor with courses
     And I'm on "create question" page for course with id "1"
     And I fill in:
       | element        | content       |

--- a/acj/static/test/features/create_user.feature
+++ b/acj/static/test/features/create_user.feature
@@ -2,13 +2,13 @@ Feature: Create User
   As user, I want to create users
 
   Scenario: Loading add user page by Create User button as admin
-    Given I'm "admin"
+    Given I'm a System Administrator
     And I'm on "home" page
     When I select "Create User" button
     Then I should be on the "create user" page
 
   Scenario: Creating a user as admin
-    Given I'm "admin"
+    Given I'm a System Administrator
     And I'm on "create user" page
     And I fill in:
       | element                     | content           |
@@ -23,8 +23,8 @@ Feature: Create User
     Then I should be on the "profile" page
     And I should see "Second Student's Profile" in "h1" on the page
 
-  Scenario: Creating a user as admin
-    Given I'm "instructor1"
+  Scenario: Creating a user as instructor
+    Given I'm an Instructor
     And I'm on "create user" page
     And I fill in:
       | element                     | content           |
@@ -38,3 +38,5 @@ Feature: Create User
     When I submit form with "Save" button
     Then I should be on the "profile" page
     And I should see "Second Student's Profile" in "h1" on the page
+
+

--- a/acj/static/test/features/step_definitions/common.js
+++ b/acj/static/test/features/step_definitions/common.js
@@ -7,31 +7,10 @@ chai.use(chaiAsPromised);
 var expect = chai.expect;
 
 var PageFactory  = require('../../factories/page_factory.js');
-var UserFactory  = require('../../factories/user_factory.js');
-var backEndMocks = require('../../factories/http_backend_mocks.js');
 
 var commonStepDefinitionsWrapper = function() {
 	var pageFactory = new PageFactory();
-    var page;
-	var userFactory = new UserFactory();
-	var mocks = [
-		backEndMocks.session,
-		backEndMocks.user,
-		backEndMocks.course,
-		backEndMocks.question
-	];
-
-	// login and setup mock backend
-	this.Given(/^I'm "([^"]*)"$/, function (username, done) {
-		backEndMocks.build(browser, mocks);
-		var loginDialog = pageFactory.createPage('login');
-		loginDialog.get('/');
-		loginDialog.login(userFactory.getUser(username)).then(function() {
-			// wait for displayname is populated before we reload the page
-			browser.wait(browser.isElementPresent(element(by.binding('loggedInUser.displayname'))), 5000);
-			done();
-		});
-	});
+    var page;   
 
 	// check title of page
 	this.Then(/^"([^"]*)" page should load$/, function (content_title, done) {
@@ -82,25 +61,21 @@ var commonStepDefinitionsWrapper = function() {
 	this.Given(/^I should see form fields:$/, function (data, done) {
 		var list = data.hashes();
         
-        var allPromises = list.map(function(item){
-            return expect(element(by.model(item.element)).isPresent()).to.become(true);
+        list.forEach(function(item){
+            expect(element(by.model(item.element)).isPresent()).to.eventually.equal(true);
         });
         
-        protractor.promise.all(allPromises).then(function(){
-            done();
-        });
+        done();
 	});
     
 	this.Given(/^I should not see form fields:$/, function (data, done) {
 		var list = data.hashes();
         
-        var allPromises = list.map(function(item){
-            return expect(element(by.model(item.element)).isPresent()).to.become(false);
+        list.forEach(function(item){
+            expect(element(by.model(item.element)).isPresent()).to.eventually.equal(false);
         });
         
-        protractor.promise.all(allPromises).then(function(){
-            done();
-        });
+        done();
 	});
     
     // generate page factory
@@ -132,10 +107,10 @@ var commonStepDefinitionsWrapper = function() {
     // page verification
 	this.When(/^I should be on the "([^"]*)" page$/, function (page, done) {
 		var page_regex = {
-			'course': /.*\/course\/\d+/,
-			'profile': /.*\/user\/\d+/,
-            'create user': /.*\/user\/create/,
-			'edit profile': /.*\/user\/\d+\/edit/
+			'course': /.*\/course\/\d+$/,
+			'profile': /.*\/user\/\d+$/,
+            'create user': /.*\/user\/create$/,
+			'edit profile': /.*\/user\/\d+\/edit$/
 		};
 		expect(browser.getCurrentUrl()).to.eventually.match(page_regex[page]).and.notify(done);
 	});
@@ -148,50 +123,43 @@ var commonStepDefinitionsWrapper = function() {
 	this.Then(/^I should see text:$/, function (data, done) {
 		var list = data.hashes();
         
-        var allPromises = list.map(function(item){
-            return expect(element(by.css(item.locator)).getText()).to.eventually.equal(item.text);
+        list.forEach(function(item){
+            expect(element(by.css(item.locator)).getText()).to.eventually.equal(item.text);
         });
         
-        protractor.promise.all(allPromises).then(function(){
-            done();
-        });
+        done();
 	});
     
 	this.Then(/^I should see "([^"]*)" on the page$/, function (locator, done) {
-        expect(element(by.css(locator)).isPresent()).to.become(true).and.notify(done);
+        expect(element(by.css(locator)).isPresent()).to.eventually.equal(true).and.notify(done);
 	});
     
-	this.Then(/^I should see:$/, function (data, done) {
+	this.Then('I should see:', function (data, done) {
 		var list = data.hashes();
         
-        var allPromises = list.map(function(item){
-            return expect(element(by.css(item.locator)).isPresent()).to.become(true).and.notify(done);
+        list.forEach(function(item){
+            expect(element(by.css(item.locator)).isPresent()).to.eventually.equal(true);
         });
         
-        protractor.promise.all(allPromises).then(function(){
-            done();
-        });
+        done();
 	});
     
-    
 	this.Then(/^I should not see "([^"]*)" on the page$/, function (locator, done) {
-        expect(element(by.css(locator)).isPresent()).to.become(false).and.notify(done);
+        expect(element(by.css(locator)).isPresent()).to.eventually.equal(false).and.notify(done);
 	});
     
 	this.Then(/^I should not see:$/, function (data, done) {
 		var list = data.hashes();
         
-        var allPromises = list.map(function(item){
-            return expect(element(by.css(item.locator)).isPresent()).to.become(false);
+        list.map(function(item){
+            expect(element(by.css(item.locator)).isPresent()).to.eventually.equal(false);
         });
         
-        protractor.promise.all(allPromises).then(function(){
-            done();
-        });
+        done();
 	});
 
     // pause test (helpful for debugging)
-	this.When(/^I should be paused$/, function (page, done) {
+	this.Then('pause', function (page, done) {
 		browser.pause();
 	});
 };

--- a/acj/static/test/features/step_definitions/setup_admin.js
+++ b/acj/static/test/features/step_definitions/setup_admin.js
@@ -1,0 +1,43 @@
+// Use the external Chai As Promised to deal with resolving promises in
+// expectations
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+
+var expect = chai.expect;
+
+var PageFactory  = require('../../factories/page_factory.js');
+var backEndMocks = require('../../factories/http_backend_mocks.js');
+
+var setupAdminStepDefinitionsWrapper = function () {
+	var pageFactory = new PageFactory();
+    
+	this.Given("I'm a System Administrator", function (done) {
+        var fixture  = require('../../fixtures/admin/default_fixture.js');
+		backEndMocks.build(browser, fixture);
+        
+		var loginDialog = pageFactory.createPage('login');
+		loginDialog.get('/');
+		loginDialog.login(fixture.loginDetails).then(function() {
+			// wait for displayname is populated before we reload the page
+			browser.wait(browser.isElementPresent(element(by.binding('loggedInUser.displayname'))), 5000);
+			done();
+		});
+	});
+    
+	this.Given("I'm a System Administrator with courses", function (done) {
+        var fixture  = require('../../fixtures/admin/has_courses_fixture.js');
+		backEndMocks.build(browser, fixture);
+        
+		var loginDialog = pageFactory.createPage('login');
+		loginDialog.get('/');
+		loginDialog.login(fixture.loginDetails).then(function() {
+			// wait for displayname is populated before we reload the page
+			browser.wait(browser.isElementPresent(element(by.binding('loggedInUser.displayname'))), 5000);
+			done();
+		});
+	});
+    
+};
+
+module.exports = setupAdminStepDefinitionsWrapper;

--- a/acj/static/test/features/step_definitions/setup_instructor.js
+++ b/acj/static/test/features/step_definitions/setup_instructor.js
@@ -1,0 +1,56 @@
+// Use the external Chai As Promised to deal with resolving promises in
+// expectations
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+
+var expect = chai.expect;
+
+var PageFactory  = require('../../factories/page_factory.js');
+var backEndMocks = require('../../factories/http_backend_mocks.js');
+
+var setupInstructorStepDefinitionsWrapper = function () {
+	var pageFactory = new PageFactory();
+    
+	this.Given("I'm an Instructor", function (done) {
+        var fixture  = require('../../fixtures/instructor/default_fixture.js');
+		backEndMocks.build(browser, fixture);
+        
+		var loginDialog = pageFactory.createPage('login');
+		loginDialog.get('/');
+		loginDialog.login(fixture.loginDetails).then(function() {
+			// wait for displayname is populated before we reload the page
+			browser.wait(browser.isElementPresent(element(by.binding('loggedInUser.displayname'))), 5000);
+			done();
+		});
+	});
+    
+	this.Given("I'm an Instructor with students", function (done) {
+        var fixture  = require('../../fixtures/instructor/has_students_fixture.js');
+		backEndMocks.build(browser, fixture);
+        
+		var loginDialog = pageFactory.createPage('login');
+		loginDialog.get('/');
+		loginDialog.login(fixture.loginDetails).then(function() {
+			// wait for displayname is populated before we reload the page
+			browser.wait(browser.isElementPresent(element(by.binding('loggedInUser.displayname'))), 5000);
+			done();
+		});
+	});
+    
+	this.Given("I'm an Instructor with courses", function (done) {
+        var fixture  = require('../../fixtures/instructor/has_courses_fixture.js');
+		backEndMocks.build(browser, fixture);
+        
+		var loginDialog = pageFactory.createPage('login');
+		loginDialog.get('/');
+		loginDialog.login(fixture.loginDetails).then(function() {
+			// wait for displayname is populated before we reload the page
+			browser.wait(browser.isElementPresent(element(by.binding('loggedInUser.displayname'))), 5000);
+			done();
+		});
+	});
+    
+};
+
+module.exports = setupInstructorStepDefinitionsWrapper;

--- a/acj/static/test/features/step_definitions/setup_student.js
+++ b/acj/static/test/features/step_definitions/setup_student.js
@@ -1,0 +1,43 @@
+// Use the external Chai As Promised to deal with resolving promises in
+// expectations
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+
+var expect = chai.expect;
+
+var PageFactory  = require('../../factories/page_factory.js');
+var backEndMocks = require('../../factories/http_backend_mocks.js');
+
+var setupStudentStepDefinitionsWrapper = function () {
+	var pageFactory = new PageFactory();
+    
+	this.Given("I'm a Student", function (done) {
+        var fixture  = require('../../fixtures/student/default_fixture.js');
+		backEndMocks.build(browser, fixture);
+        
+		var loginDialog = pageFactory.createPage('login');
+		loginDialog.get('/');
+		loginDialog.login(fixture.loginDetails).then(function() {
+			// wait for displayname is populated before we reload the page
+			browser.wait(browser.isElementPresent(element(by.binding('loggedInUser.displayname'))), 5000);
+			done();
+		});
+	});
+    
+	this.Given("I'm a Student with courses", function (done) {
+        var fixture  = require('../../fixtures/student/has_courses_fixture.js');
+		backEndMocks.build(browser, fixture);
+        
+		var loginDialog = pageFactory.createPage('login');
+		loginDialog.get('/');
+		loginDialog.login(fixture.loginDetails).then(function() {
+			// wait for displayname is populated before we reload the page
+			browser.wait(browser.isElementPresent(element(by.binding('loggedInUser.displayname'))), 5000);
+			done();
+		});
+	});
+    
+};
+
+module.exports = setupStudentStepDefinitionsWrapper;

--- a/acj/static/test/features/support/after_hooks.js
+++ b/acj/static/test/features/support/after_hooks.js
@@ -4,7 +4,8 @@ var myAfterHooks = function () {
 		// playing with.
 		browser.executeAsyncScript(
 			'var cb = arguments[arguments.length - 1];' +
-			'window.angular.element("#logout-link").scope().logout().then(cb);').then(function() {
+			'var logoutScope = window.angular.element("#logout-link").scope();' +
+			'if(logoutScope) { logoutScope.logout().then(cb); } else { cb() }').then(function() {
 				browser.manage().deleteAllCookies().then(function () {
 					// Release control:
 					callback();

--- a/acj/static/test/features/view_home.feature
+++ b/acj/static/test/features/view_home.feature
@@ -2,53 +2,43 @@ Feature: View Home
   As user, I want to view courses on the home page
 
   Scenario: Loading home page as admin
-    Given I'm "admin"
+    Given I'm a System Administrator with courses
     And I'm on "home" page
     Then I should see my courses with names:
-      | name               |
-      | Test Course 1      |
-      | Test Course 2      |
+      | name          |
+      | CHEM 111      |
+      | PHYS 101      |
 
   Scenario: Filtering home page courses as admin
-    Given I'm "admin"
+    Given I'm a System Administrator with courses
     And I'm on "home" page
-    Then I should see "2" courses
-    And I should see my courses with names:
-      | name               |
-      | Test Course 1      |
-      | Test Course 2      |
-    When I filter home page courses by "Course 1"
+    When I filter home page courses by "CHEM"
     Then I should see "1" courses
     And I should see my courses with names:
-      | name               |
-      | Test Course 1      |
+      | name          |
+      | CHEM 111      |
 
   Scenario: Loading home page as instructor
-    Given I'm "instructor1"
+    Given I'm an Instructor with courses
     And I'm on "home" page
     Then I should see my courses with names:
-      | name               |
-      | Test Course 1      |
-      | Test Course 2      |
+      | name          |
+      | CHEM 111      |
+      | PHYS 101      |
 
   Scenario: Filtering home page courses as instructor
-    Given I'm "instructor1"
+    Given I'm an Instructor with courses
     And I'm on "home" page
-    Then I should see "2" courses
-    And I should see my courses with names:
-      | name               |
-      | Test Course 1      |
-      | Test Course 2      |
-    When I filter home page courses by "Course 1"
+    When I filter home page courses by "CHEM"
     Then I should see "1" courses
     And I should see my courses with names:
-      | name               |
-      | Test Course 1      |
+      | name          |
+      | CHEM 111      |
 
   Scenario: Loading home page as student
-    Given I'm "student1"
+    Given I'm a Student with courses
     And I'm on "home" page
     Then I should see my courses with names:
-      | name               |
-      | Test Course 1      |
-      | Test Course 2      |
+      | name          |
+      | CHEM 111      |
+      | PHYS 101      |

--- a/acj/static/test/features/view_user.feature
+++ b/acj/static/test/features/view_user.feature
@@ -2,7 +2,7 @@ Feature: View Profile
   As user, I want to view profiles of users
 
   Scenario: Loading own profile as admin
-    Given I'm "admin"
+    Given I'm a System Administrator
     And I'm on "home" page
     When I select "Profile" button
     Then I should be on the "profile" page
@@ -23,7 +23,7 @@ Feature: View Profile
       
   # TODO: add steps to get to other user's profile page without direct link
   Scenario: Loading other user's profile as admin
-    Given I'm "admin"
+    Given I'm a System Administrator
     And I'm on "user" page for user with id "2"
     Then I should see text:
       | locator                     | text                          |
@@ -41,7 +41,7 @@ Feature: View Profile
       | #user_lastonline            |
   
   Scenario: Loading own profile as instructor
-    Given I'm "instructor1"
+    Given I'm an Instructor
     And I'm on "home" page
     When I select "Profile" button
     Then I should be on the "profile" page
@@ -62,7 +62,7 @@ Feature: View Profile
       
   # TODO: add steps to get to other user's profile page without direct link
   Scenario: Loading other user's profile as instructor with edit permissions
-    Given I'm "instructor1"
+    Given I'm an Instructor with students
     And I'm on "user" page for user with id "3"
     Then I should see text:
       | locator                     | text                          |
@@ -81,7 +81,7 @@ Feature: View Profile
 
   # TODO: add steps to get to other user's profile page without direct link
   Scenario: Loading other user's profile as instructor without edit permissions
-    Given I'm "instructor1"
+    Given I'm an Instructor with students
     And I'm on "user" page for user with id "4"
     Then I should see text:
       | locator                     | text                          |
@@ -100,7 +100,7 @@ Feature: View Profile
 
 
   Scenario: Loading own profile as student
-    Given I'm "student1"
+    Given I'm a Student
     And I'm on "home" page
     When I select "Profile" button
     Then I should be on the "profile" page
@@ -121,7 +121,7 @@ Feature: View Profile
 
   # TODO: add steps to get to other user's profile page without direct link
   Scenario: Loading other user's profile as student
-    Given I'm "student1"
+    Given I'm a Student
     And I'm on "user" page for user with id "2"
     Then I should see text:
       | locator                     | text                          |

--- a/acj/static/test/fixtures/admin/default_fixture.js
+++ b/acj/static/test/fixtures/admin/default_fixture.js
@@ -1,0 +1,42 @@
+var UserFactory = require('../../factories/user_factory.js');
+var userFactory = new UserFactory();
+
+var SessionFactory  = require('../../factories/session_factory.js');
+var sessionFactory = new SessionFactory();
+
+var storage = {
+    session: {},
+    users: [],
+    userTypes: [
+        { "id": 1, "name": "Student" }, 
+        { "id": 2, "name": "Instructor" }, 
+        { "id": 3, "name": "System Administrator"  }
+    ]
+}
+
+var admin = userFactory.generateUser(1, "System Administrator", {
+    username: "root",
+    displayname: "root",
+    firstname: "JaNy",
+    lastname: "bwsV",
+    fullname: "JaNy bwsV",
+});
+storage.users.push(admin);
+
+var instructor = userFactory.generateUser(2, "Instructor", {
+    username: "instructor1",
+    displayname: "First Instructor",
+    firstname: "First",
+    lastname: "Instructor",
+    fullname: "First Instructor",
+    email: "first.instructor@exmple.com"
+});
+storage.users.push(instructor);
+
+
+
+storage.loginDetails = { id: admin.id, username: admin.username, password: "password" };
+var session = sessionFactory.generateSession(admin.id, admin.system_role, {});
+storage.session = session;
+
+module.exports = storage;

--- a/acj/static/test/fixtures/admin/has_courses_fixture.js
+++ b/acj/static/test/fixtures/admin/has_courses_fixture.js
@@ -1,0 +1,59 @@
+var UserFactory = require('../../factories/user_factory.js');
+var userFactory = new UserFactory();
+
+var SessionFactory  = require('../../factories/session_factory.js');
+var sessionFactory = new SessionFactory();
+
+var CourseFactory  = require('../../factories/course_factory.js');
+var courseFactory = new CourseFactory();
+
+var storage = {
+    session: {},
+    users: [],
+    courses: [],
+    course_criteria: {},
+    users_and_courses: [],
+    userTypes: [
+        { "id": 1, "name": "Student" }, 
+        { "id": 2, "name": "Instructor" }, 
+        { "id": 3, "name": "System Administrator"  }
+    ]
+}
+
+var admin = userFactory.generateUser(1, "System Administrator", {
+    username: "root",
+    displayname: "root",
+    firstname: "JaNy",
+    lastname: "bwsV",
+    fullname: "JaNy bwsV",
+});
+storage.users.push(admin);
+
+var course1 = courseFactory.generateCourse(1, {
+    name: "CHEM 111",
+    description: "<p>CHEM 111 description<p>",
+});
+storage.courses.push(course1);
+
+var course2 = courseFactory.generateCourse(1, {
+    name: "PHYS 101",
+    description: "<p>PHYS 101  description<p>",
+});
+storage.courses.push(course2);
+
+// users_and_courses
+storage.users_and_courses[admin.id] = [
+    { courseId: course1.id, role: 2 },
+    { courseId: course2.id, role: 2 }
+];
+
+// course_criteria
+storage.course_criteria[course1.id] = [1];
+storage.course_criteria[course2.id] = [1];
+
+
+storage.loginDetails = { id: admin.id, username: admin.username, password: "password" };
+var session = sessionFactory.generateSession(admin.id, admin.system_role, {});
+storage.session = session;
+
+module.exports = storage;

--- a/acj/static/test/fixtures/instructor/default_fixture.js
+++ b/acj/static/test/fixtures/instructor/default_fixture.js
@@ -1,0 +1,38 @@
+var UserFactory = require('../../factories/user_factory.js');
+var userFactory = new UserFactory();
+
+var SessionFactory  = require('../../factories/session_factory.js');
+var sessionFactory = new SessionFactory();
+
+var storage = {
+    session: {},
+    users: []
+}
+
+var admin = userFactory.generateUser(1, "System Administrator", {
+    username: "root",
+    displayname: "root",
+    firstname: "JaNy",
+    lastname: "bwsV",
+    fullname: "JaNy bwsV",
+});
+storage.users.push(admin);
+
+var instructor = userFactory.generateUser(2, "Instructor", {
+    username: "instructor1",
+    displayname: "First Instructor",
+    firstname: "First",
+    lastname: "Instructor",
+    fullname: "First Instructor",
+    email: "first.instructor@exmple.com"
+});
+storage.users.push(instructor);
+
+
+
+storage.loginDetails = { id: instructor.id, username: instructor.username, password: "password" };
+var session = sessionFactory.generateSession(instructor.id, instructor.system_role, {});
+storage.session = session;
+
+
+module.exports = storage;

--- a/acj/static/test/fixtures/instructor/has_courses_fixture.js
+++ b/acj/static/test/fixtures/instructor/has_courses_fixture.js
@@ -1,0 +1,78 @@
+var UserFactory = require('../../factories/user_factory.js');
+var userFactory = new UserFactory();
+
+var SessionFactory  = require('../../factories/session_factory.js');
+var sessionFactory = new SessionFactory();
+
+var CourseFactory  = require('../../factories/course_factory.js');
+var courseFactory = new CourseFactory();
+
+var storage = {
+    session: {},
+    users: [],
+    courses: [],
+    course_criteria: {},
+    users_and_courses: []
+}
+
+var admin = userFactory.generateUser(1, "System Administrator", {
+    username: "root",
+    displayname: "root",
+    firstname: "JaNy",
+    lastname: "bwsV",
+    fullname: "JaNy bwsV",
+});
+storage.users.push(admin);
+
+var instructor = userFactory.generateUser(2, "Instructor", {
+    username: "instructor1",
+    displayname: "First Instructor",
+    firstname: "First",
+    lastname: "Instructor",
+    fullname: "First Instructor",
+    email: "first.instructor@exmple.com"
+});
+storage.users.push(instructor);
+
+
+var course1 = courseFactory.generateCourse(1, {
+    name: "CHEM 111",
+    description: "<p>CHEM 111 description<p>",
+});
+storage.courses.push(course1);
+
+var course2 = courseFactory.generateCourse(1, {
+    name: "PHYS 101",
+    description: "<p>PHYS 101  description<p>",
+});
+storage.courses.push(course2);
+
+// users_and_courses
+storage.users_and_courses[instructor.id] = [
+    { courseId: course1.id, role: 2 },
+    { courseId: course2.id, role: 2 }
+];
+
+// course_criteria
+storage.course_criteria[course1.id] = [1];
+storage.course_criteria[course2.id] = [1];
+
+storage.loginDetails = { id: instructor.id, username: instructor.username, password: "password" };
+var session = sessionFactory.generateSession(instructor.id, instructor.system_role, {		
+    "Courses": {
+        "delete": {'1': false, '2': false},
+        "edit": {'1': true, '2': true},
+        "manage": {'1': false, '2': false},
+        "read": {'1': true, '2': true}
+    },
+    "PostsForQuestions": {
+        "create": {'1': true, '2': true},
+        "delete": {'1': true, '2': true},
+        "edit": {'1': true, '2': true},
+        "manage": {'1': true, '2': true},
+        "read": {'1': true, '2': true}
+    },
+});
+storage.session = session;
+
+module.exports = storage;

--- a/acj/static/test/fixtures/instructor/has_students_fixture.js
+++ b/acj/static/test/fixtures/instructor/has_students_fixture.js
@@ -1,0 +1,78 @@
+var UserFactory = require('../../factories/user_factory.js');
+var userFactory = new UserFactory();
+
+var SessionFactory  = require('../../factories/session_factory.js');
+var sessionFactory = new SessionFactory();
+
+var CourseFactory  = require('../../factories/course_factory.js');
+var courseFactory = new CourseFactory();
+
+var storage = {
+    session: {},
+    users: [],
+    courses: [],
+    users_and_courses: []
+}
+
+var admin = userFactory.generateUser(1, "System Administrator", {
+    username: "root",
+    displayname: "root",
+    firstname: "JaNy",
+    lastname: "bwsV",
+    fullname: "JaNy bwsV",
+});
+storage.users.push(admin);
+
+var instructor = userFactory.generateUser(2, "Instructor", {
+    username: "instructor1",
+    displayname: "First Instructor",
+    firstname: "First",
+    lastname: "Instructor",
+    fullname: "First Instructor",
+    email: "first.instructor@exmple.com"
+});
+storage.users.push(instructor);
+
+var student1 = userFactory.generateUser(3, "Student", {
+    username: "student1",
+    displayname: "First Student",
+    firstname: "First",
+    lastname: "Student",
+    fullname: "First Student",
+    email: "first.student@exmple.com"
+});
+storage.users.push(student1);
+
+var student2 = userFactory.generateUser(4, "Student", {
+    username: "student2",
+    displayname: "Second Student",
+    firstname: "Second",
+    lastname: "Student",
+    fullname: "Second Student",
+    email: "second.student@exmple.com"
+});
+storage.users.push(student2);
+
+
+var course = courseFactory.generateCourse(1, {
+    name: "CHEM 111",
+    description: "<p>CHEM 111 description<p>",
+});
+storage.courses.push(course);
+
+// users_and_courses
+storage.users_and_courses[instructor.id] = [
+    { courseId: course.id, role: 2 }
+];
+
+storage.users_and_courses[student1.id] = [
+    { courseId: course.id, role: 4 }
+];
+
+
+storage.loginDetails = { id: instructor.id, username: instructor.username, password: "password" };
+var session = sessionFactory.generateSession(instructor.id, instructor.system_role, {});
+storage.session = session;
+
+
+module.exports = storage;

--- a/acj/static/test/fixtures/student/default_fixture.js
+++ b/acj/static/test/fixtures/student/default_fixture.js
@@ -1,0 +1,48 @@
+var UserFactory = require('../../factories/user_factory.js');
+var userFactory = new UserFactory();
+
+var SessionFactory  = require('../../factories/session_factory.js');
+var sessionFactory = new SessionFactory();
+
+var storage = {
+    session: {},
+    users: []
+}
+
+var admin = userFactory.generateUser(1, "System Administrator", {
+    username: "root",
+    displayname: "root",
+    firstname: "JaNy",
+    lastname: "bwsV",
+    fullname: "JaNy bwsV",
+});
+storage.users.push(admin);
+
+var instructor = userFactory.generateUser(2, "Instructor", {
+    username: "instructor1",
+    displayname: "First Instructor",
+    firstname: "First",
+    lastname: "Instructor",
+    fullname: "First Instructor",
+    email: "first.instructor@exmple.com"
+});
+storage.users.push(instructor);
+
+var student = userFactory.generateUser(3, "Student", {
+    username: "student1",
+    displayname: "First Student",
+    firstname: "First",
+    lastname: "Student",
+    fullname: "First Student",
+    email: "first.student@exmple.com"
+});
+storage.users.push(student);
+
+
+
+storage.loginDetails = { id: student.id, username: student.username, password: "password" };
+var session = sessionFactory.generateSession(student.id, student.system_role, {});
+storage.session = session;
+
+
+module.exports = storage;

--- a/acj/static/test/fixtures/student/has_courses_fixture.js
+++ b/acj/static/test/fixtures/student/has_courses_fixture.js
@@ -1,0 +1,88 @@
+var UserFactory = require('../../factories/user_factory.js');
+var userFactory = new UserFactory();
+
+var SessionFactory  = require('../../factories/session_factory.js');
+var sessionFactory = new SessionFactory();
+
+var CourseFactory  = require('../../factories/course_factory.js');
+var courseFactory = new CourseFactory();
+
+var storage = {
+    session: {},
+    users: [],
+    courses: [],
+    course_criteria: {},
+    users_and_courses: []
+}
+
+var admin = userFactory.generateUser(1, "System Administrator", {
+    username: "root",
+    displayname: "root",
+    firstname: "JaNy",
+    lastname: "bwsV",
+    fullname: "JaNy bwsV",
+});
+storage.users.push(admin);
+
+var instructor = userFactory.generateUser(2, "Instructor", {
+    username: "instructor1",
+    displayname: "First Instructor",
+    firstname: "First",
+    lastname: "Instructor",
+    fullname: "First Instructor",
+    email: "first.instructor@exmple.com"
+});
+storage.users.push(instructor);
+
+var student = userFactory.generateUser(3, "Student", {
+    username: "student1",
+    displayname: "First Student",
+    firstname: "First",
+    lastname: "Student",
+    fullname: "First Student",
+    email: "first.student@exmple.com"
+});
+storage.users.push(student);
+
+
+var course1 = courseFactory.generateCourse(1, {
+    name: "CHEM 111",
+    description: "<p>CHEM 111 description<p>",
+});
+storage.courses.push(course1);
+
+var course2 = courseFactory.generateCourse(1, {
+    name: "PHYS 101",
+    description: "<p>PHYS 101  description<p>",
+});
+storage.courses.push(course2);
+
+// users_and_courses
+storage.users_and_courses[student.id] = [
+    { courseId: course1.id, role: 4 },
+    { courseId: course2.id, role: 4 }
+];
+
+// course_criteria
+storage.course_criteria[course1.id] = [1];
+storage.course_criteria[course2.id] = [1];
+
+storage.loginDetails = { id: student.id, username: student.username, password: "password" };
+var session = sessionFactory.generateSession(student.id, student.system_role, {
+    "Courses": {
+        "delete": {'1': false, '2': false},
+        "edit": {'1': false, '2': false},
+        "manage": {'1': false, '2': false},
+        "read": {'1': true, '2': true}
+    },
+    "PostsForQuestions": {
+        "create": {'1': false, '2': false},
+        "delete": {'1': false, '2': false},
+        "edit": {'1': false, '2': false},
+        "manage": {'1': false, '2': false},
+        "read": {'1': true, '2': true}
+    },
+});
+storage.session = session;
+
+module.exports = storage;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "karma-phantomjs-launcher": "~0.2",
     "phantomjs": "~2.1",
     "lodash": "^3.10",
-    "protractor": "~2.5.1"
+    "protractor": "~3.2.2",
+    "object-assign": "~4.0"
   }
 }


### PR DESCRIPTION
Test data is now initialized based on the "I'm an x" steps which moved into separate step files by user type so that it is easier to keep track of. These steps will load a fixture file which will create the necessary test data using factories.

http_backend_mocks has been refactored putting all the api request mocks into one module. This module contains a storage variable with some default data that will be extended by the fixture data when initialized.

related to #261