### PR TITLE
Modify Travis CI build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,18 @@ env:
   global:
     - secure: imeWytgo5kReh6HgPqhaWlsK+oWN8TObyYlrrsA6CASmeJT6GEOpghXimJ8avNpGmcNHji+3GfWKuirUBew9RxAaiYkdjrFZ6nPibmt1HJJfiL1hQMHhp9rCnMBdxevH4/8Wl86bN5/YIwglXhqDplVEmrWqiHzKfw9BBRfOrVc=
     - secure: D5aySdfAWW2Z5aJN3PSW4FBDKSGEbCSPgDUBEoAkwXbmpvZA29RqUP4O2P6wMC7CeVUI4A7+bAalsgIgYt3YLsT1QJE3IV679axHPDdEIP45oZy4+S7KkI4cCfI+R6lnwU7Lp/eW42lc+mugKLZ2hDs0mcx6+tHAoazGgIRyRzA=
-  matrix:
-    - DB=sqlite DISABLE_MOCK=true DATABASE_URI="sqlite:///:memory:"
-    - DB=mysql DISABLE_MOCK=true DATABASE_URI="mysql+pymysql://root@localhost/acj"
+  matrix: 
+    - DISABLE_MOCK=true DB=sqlite DATABASE_URI="sqlite:///:memory:"
+    - DISABLE_MOCK=true DB=mysql DATABASE_URI="mysql+pymysql://root@localhost/acj"
+matrix:   
+  include:
+    - python: "3.4"
+      env: INTEGRATION_TEST=true TEST_BROWSER_NAME=chrome TEST_BROWSER_VERSION=50 DISABLE_MOCK=false DB=sqlite DATABASE_URI="sqlite:///:memory:" 
+    - python: "3.4"
+      env: INTEGRATION_TEST=true TEST_BROWSER_NAME=firefox TEST_BROWSER_VERSION=44 DISABLE_MOCK=false DB=sqlite DATABASE_URI="sqlite:///:memory:" 
+  allow_failures:
+      - env: INTEGRATION_TEST=true TEST_BROWSER_NAME=chrome TEST_BROWSER_VERSION=50 DISABLE_MOCK=false DB=sqlite DATABASE_URI="sqlite:///:memory:" 
+      - env: INTEGRATION_TEST=true TEST_BROWSER_NAME=firefox TEST_BROWSER_VERSION=44 DISABLE_MOCK=false DB=sqlite DATABASE_URI="sqlite:///:memory:" 
 
 addons:
   sauce_connect: true
@@ -25,10 +34,7 @@ before_script:
 install:
   - "make deps"
 
-script:
-  - python -m unittest discover -s acj/tests/
-  - node_modules/karma/bin/karma start acj/static/test/config/karma.conf.js --single-run --browsers PhantomJS
-  - DISABLE_MOCK=false node_modules/.bin/gulp test:ci
+script: ./scripts/travis_script.sh
 
 notifications:
   slack: ubcctlt:cyfS7OeXqRjqhyrpIMHJ0SRd

--- a/acj/static/test/config/protractor_saucelab.js
+++ b/acj/static/test/config/protractor_saucelab.js
@@ -8,19 +8,13 @@ exports.config = {
     specs: ['../features/**/*.feature'],
 	framework: 'cucumber',
 	multiCapabilities: [{
-		'browserName': 'chrome',
+		'browserName': process.env.TEST_BROWSER_NAME,
 		'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
 		'build': process.env.TRAVIS_BUILD_NUMBER,
 		'name': 'acj suite tests',
-		'version': '39',
-		'selenium-version': '2.52.0'
-	}, {
-		'browserName': 'firefox',
-		'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
-		'build': process.env.TRAVIS_BUILD_NUMBER,
-		'name': 'acj suite tests',
-		'version': '34',
-		'selenium-version': '2.52.0'
+		'version': process.env.TEST_BROWSER_VERSION,
+		'selenium-version': '2.52.0',
+		'maxDuration': 3600 // 1 hour
 	}],
     cucumberOpts: {
         format: 'pretty'

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+if [ "${INTEGRATION_TEST}" = "true" ]; then
+	node_modules/.bin/gulp test:ci
+else 
+    python -m unittest discover -s acj/tests/
+    node_modules/karma/bin/karma start acj/static/test/config/karma.conf.js --single-run --browsers PhantomJS
+fi


### PR DESCRIPTION
Integration should tests can now in their own jobs (one from chrome and one for firefox). This should help increase the stability of the integration tests and speed up the overall process.

Helps Address #273