### PR TITLE
Add rank to API Scores

### DIFF
--- a/acj/api/dataformat/__init__.py
+++ b/acj/api/dataformat/__init__.py
@@ -134,7 +134,9 @@ def get_answer(restrict_user=True):
         'file': fields.Nested(get_file(), allow_null=True),
         'flagged': fields.Boolean,
 
-        'scores': fields.List(fields.Nested(get_score())),
+        'scores': fields.List(fields.Nested(get_score(
+            restrict_user=restrict_user
+        ))),
         'comment_count': fields.Integer,
         'private_comment_count': fields.Integer,
         'public_comment_count': fields.Integer,
@@ -209,7 +211,6 @@ def get_file():
 
 def get_comparison(restrict_user=True, with_answers=True):
     ret = {
-        'id': fields.Integer,
         'course_id': fields.Integer,
         'assignment_id': fields.Integer,
         'criterion_id': fields.Integer,
@@ -246,7 +247,8 @@ def get_comparison_set(restrict_user=True):
         'user_id': fields.Integer,
 
         'comparisons': fields.List(fields.Nested(get_comparison(
-            restrict_user=restrict_user, with_answers=False))),
+            restrict_user=restrict_user, with_answers=False
+        ))),
 
         'answer1_id': fields.Integer,
         'answer2_id': fields.Integer,
@@ -278,10 +280,13 @@ def get_import_users_results(restrict_user=True):
     }
 
 
-def get_score():
-    return {
-        'id': fields.Integer,
-        'criterion_id': fields.Integer,
-        'answer_id': fields.Integer,
-        'normalized_score': fields.Integer
+def get_score(restrict_user=True):
+    ret = {
+        'criterion_id': fields.Integer
     }
+    if restrict_user:
+        ret['rank'] = fields.Integer
+    else:
+        ret['normalized_score'] = fields.Integer
+
+    return ret

--- a/acj/models/score.py
+++ b/acj/models/score.py
@@ -65,6 +65,30 @@ class Score(DefaultTableMixin, WriteTrackingMixin):
             opponents=self.opponents
         )
 
+    @hybrid_property
+    def rank(self):
+        scores = Score.get_assignment_scores(self.assignment_id, self.criterion_id)
+
+        for index, score in enumerate(scores):
+            if score.normalized_score == self.normalized_score:
+                return index + 1
+
+        return None
+
+    # TODO: this should be cached
+    @classmethod
+    def get_assignment_scores(cls, assignment_id, criterion_id):
+        return Score.query \
+            .with_entities(Score.normalized_score) \
+            .distinct() \
+            .filter(and_(
+                Score.assignment_id == assignment_id,
+                Score.criterion_id == criterion_id
+            )) \
+            .order_by(Score.normalized_score.desc()) \
+            .all()
+
+
     @classmethod
     def __declare_last__(cls):
         super(cls, cls).__declare_last__()

--- a/acj/static/modules/assignment/assignment-module.js
+++ b/acj/static/modules/assignment/assignment-module.js
@@ -556,60 +556,20 @@ module.controller("AssignmentViewController",
 			}
 			$scope.answers = AnswerResource.get(params, function(response) {
 				$scope.totalNumAnswers = response.total;
-			});
-			// TO DO: grab the right array of answer ids/scores depending on the criteria selected and load into allScores here
-			// (can use $scope.answerFilters.orderBy to grab the criteria ID for requesting the scores)
-			$scope.allScores = {
-				"104":"0",
-				"95":"0",
-				"85":"4.38635",
-				"183":"2.19318",
-				"110":"2.19318",
-				"109":"2.19318",
-				"99":"2.19318",
-				"96":"1.96212",
-				"98":"1.61186",
-				"112":"1.46212",
-				"108":"1.46212",
-				"94":"1.46212",
-				"84":"1.23106",
-				"83":"1.23106",
-				"81":"0.768941",
-				"97":"0.731059" };
-			$scope.rankScores($scope.allScores);
-		};
 
-		// function to show the simple ranking for the student view
-		$scope.rankScores = function(allScores) {
-			// first sort scores high-to-low
-			$scope.rankSort = [];
-			for (var prop in allScores) {
-				if (allScores.hasOwnProperty(prop)) {
-					$scope.rankSort.push({
-						'key': prop,
-						'value': allScores[prop]
-					});
-				}
-			}
-			// need to sort by id (key) first to get ties to show up correctly later
-			$scope.rankSort.sort(function(a, b) { return b.key - a.key; });
-			$scope.rankSort.sort(function(a, b) { return b.value - a.value; });
-			// then loop through scores to increment ranking number
-			$scope.rankNumber = 0;
-			var prevScore = -1;
-			var tied = "";
-			for (var answer in $scope.rankSort) {
-				if (prevScore != $scope.rankSort[answer].value) {
-					$scope.rankNumber += 1;
-					tied = "";
-				}
-				if (prevScore == $scope.rankSort[answer].value) {
-					tied = " (tied)";
-				}
-				// now overwrite score with ranking number plus tied status
-				allScores[$scope.rankSort[answer].key] = ($scope.rankNumber+tied);
-				prevScore = $scope.rankSort[answer].value;
-			}
+                $scope.rankCount = {};
+                angular.forEach(response.objects, function(answer) {
+                    angular.forEach(answer.scores, function(score) {
+                        if (score.criterion_id == $scope.answerFilters.orderBy) {
+                            if ($scope.rankCount[score.rank] == undefined) {
+                                $scope.rankCount[score.rank] = 1;
+                            } else {
+                                ++$scope.rankCount[score.rank];
+                            }
+                        }
+                    });
+                });
+			});
 		};
 
 		var filterWatcher = function(newValue, oldValue) {

--- a/acj/static/modules/assignment/assignment-module_spec.js
+++ b/acj/static/modules/assignment/assignment-module_spec.js
@@ -290,21 +290,15 @@ describe('course-module', function () {
                 "public_comment_count": 0,
                 "scores": [
                     {
-                        "answer_id": 6,
                         "criterion_id": 1,
-                        "id": 13,
                         "normalized_score": 100
                     },
                     {
-                        "answer_id": 6,
                         "criterion_id": 2,
-                        "id": 15,
                         "normalized_score": 100
                     },
                     {
-                        "answer_id": 6,
                         "criterion_id": 3,
-                        "id": 17,
                         "normalized_score": 100
                     }
                 ],
@@ -329,21 +323,15 @@ describe('course-module', function () {
                 "public_comment_count": 0,
                 "scores": [
                     {
-                        "answer_id": 4,
                         "criterion_id": 1,
-                        "id": 1,
                         "normalized_score": 78
                     },
                     {
-                        "answer_id": 4,
                         "criterion_id": 2,
-                        "id": 3,
                         "normalized_score": 78
                     },
                     {
-                        "answer_id": 4,
                         "criterion_id": 3,
-                        "id": 5,
                         "normalized_score": 100
                     }
                 ],
@@ -368,21 +356,15 @@ describe('course-module', function () {
                 "public_comment_count": 0,
                 "scores": [
                     {
-                        "answer_id": 3,
                         "criterion_id": 1,
-                        "id": 8,
                         "normalized_score": 78
                     },
                     {
-                        "answer_id": 3,
                         "criterion_id": 2,
-                        "id": 10,
                         "normalized_score": 78
                     },
                     {
-                        "answer_id": 3,
                         "criterion_id": 3,
-                        "id": 12,
                         "normalized_score": 78
                     }
                 ],
@@ -407,21 +389,15 @@ describe('course-module', function () {
                 "public_comment_count": 0,
                 "scores": [
                     {
-                        "answer_id": 9,
                         "criterion_id": 1,
-                        "id": 7,
                         "normalized_score": 68
                     },
                     {
-                        "answer_id": 9,
                         "criterion_id": 2,
-                        "id": 9,
                         "normalized_score": 68
                     },
                     {
-                        "answer_id": 9,
                         "criterion_id": 3,
-                        "id": 11,
                         "normalized_score": 68
                     }
                 ],
@@ -446,21 +422,15 @@ describe('course-module', function () {
                 "public_comment_count": 0,
                 "scores": [
                     {
-                        "answer_id": 7,
                         "criterion_id": 1,
-                        "id": 2,
                         "normalized_score": 68
                     },
                     {
-                        "answer_id": 7,
                         "criterion_id": 2,
-                        "id": 4,
                         "normalized_score": 36
                     },
                     {
-                        "answer_id": 7,
                         "criterion_id": 3,
-                        "id": 6,
                         "normalized_score": 36
                     }
                 ],
@@ -485,21 +455,15 @@ describe('course-module', function () {
                 "public_comment_count": 0,
                 "scores": [
                     {
-                        "answer_id": 5,
                         "criterion_id": 1,
-                        "id": 19,
                         "normalized_score": 68
                     },
                     {
-                        "answer_id": 5,
                         "criterion_id": 2,
-                        "id": 21,
                         "normalized_score": 68
                     },
                     {
-                        "answer_id": 5,
                         "criterion_id": 3,
-                        "id": 23,
                         "normalized_score": 36
                     }
                 ],
@@ -524,21 +488,15 @@ describe('course-module', function () {
                 "public_comment_count": 0,
                 "scores": [
                     {
-                        "answer_id": 2,
                         "criterion_id": 1,
-                        "id": 26,
                         "normalized_score": 68
                     },
                     {
-                        "answer_id": 2,
                         "criterion_id": 2,
-                        "id": 28,
                         "normalized_score": 68
                     },
                     {
-                        "answer_id": 2,
                         "criterion_id": 3,
-                        "id": 30,
                         "normalized_score": 36
                     }
                 ],
@@ -563,21 +521,15 @@ describe('course-module', function () {
                 "public_comment_count": 0,
                 "scores": [
                     {
-                        "answer_id": 10,
                         "criterion_id": 1,
-                        "id": 20,
                         "normalized_score": 57
                     },
                     {
-                        "answer_id": 10,
                         "criterion_id": 2,
-                        "id": 22,
                         "normalized_score": 36
                     },
                     {
-                        "answer_id": 10,
                         "criterion_id": 3,
-                        "id": 24,
                         "normalized_score": 78
                     }
                 ],
@@ -602,21 +554,15 @@ describe('course-module', function () {
                 "public_comment_count": 0,
                 "scores": [
                     {
-                        "answer_id": 8,
                         "criterion_id": 1,
-                        "id": 14,
                         "normalized_score": 57
                     },
                     {
-                        "answer_id": 8,
                         "criterion_id": 2,
-                        "id": 16,
                         "normalized_score": 57
                     },
                     {
-                        "answer_id": 8,
                         "criterion_id": 3,
-                        "id": 18,
                         "normalized_score": 36
                     }
                 ],
@@ -641,21 +587,15 @@ describe('course-module', function () {
                 "public_comment_count": 0,
                 "scores": [
                     {
-                        "answer_id": 1,
                         "criterion_id": 1,
-                        "id": 25,
                         "normalized_score": 36
                     },
                     {
-                        "answer_id": 1,
                         "criterion_id": 2,
-                        "id": 27,
                         "normalized_score": 100
                     },
                     {
-                        "answer_id": 1,
                         "criterion_id": 3,
-                        "id": 29,
                         "normalized_score": 100
                     }
                 ],
@@ -930,9 +870,6 @@ describe('course-module', function () {
                 expect($rootScope.comments.objects).toEqual(comments);
                 expect($rootScope.assignment.comment_count).toEqual(comments.length);
             });
-
-            // updateAnswerList
-            // rankScores
         });
 	});
 

--- a/acj/static/modules/assignment/assignment-view-partial.html
+++ b/acj/static/modules/assignment/assignment-view-partial.html
@@ -274,7 +274,7 @@
 					<!-- Student Rank (not used for instructor answers) -->
 					<p class="pull-right score-display" ng-if="!canManageAssignment && score.criterion_id==answerFilters.orderBy && answer.scores.length > 0" ng-repeat="score in answer.scores">
 						<em>
-							Students Ranked: <strong>{{allScores[answer.id]}}</strong>
+							Students Ranked: <strong>{{score.rank}} <span ng-if="rankCount[score.rank] > 1">(tied)</span></strong>
 						</em>
 					</p>
 					<!-- No Student Score/Rank -->

--- a/acj/tests/api/test_answers.py
+++ b/acj/tests/api/test_answers.py
@@ -49,6 +49,10 @@ class AnswersAPITests(ACJAPITestCase):
             for i, expected in enumerate(expected_answers.items):
                 actual = actual_answers[i]
                 self.assertEqual(expected.content, actual['content'])
+                self.assertEqual(len(expected.scores), len(actual['scores']))
+                for index, score in enumerate(expected.scores):
+                    self.assertEqual(score.rank, actual['scores'][index]['rank'])
+                    self.assertFalse('normalized_score' in actual['scores'][index])
             self.assertEqual(1, rv.json['page'])
             self.assertEqual(2, rv.json['pages'])
             self.assertEqual(20, rv.json['per_page'])
@@ -65,6 +69,10 @@ class AnswersAPITests(ACJAPITestCase):
             for i, expected in enumerate(expected_answers.items):
                 actual = actual_answers[i]
                 self.assertEqual(expected.content, actual['content'])
+                self.assertEqual(len(expected.scores), len(actual['scores']))
+                for index, score in enumerate(expected.scores):
+                    self.assertEqual(score.rank, actual['scores'][index]['rank'])
+                    self.assertFalse('normalized_score' in actual['scores'][index])
             self.assertEqual(2, rv.json['page'])
             self.assertEqual(2, rv.json['pages'])
             self.assertEqual(20, rv.json['per_page'])
@@ -342,6 +350,10 @@ class AnswersAPITests(ACJAPITestCase):
             self.assertEqual(assignment_id, rv.json['assignment_id'])
             self.assertEqual(answer.user_id, rv.json['user_id'])
             self.assertEqual(answer.content, rv.json['content'])
+            self.assertEqual(len(answer.scores), len(rv.json['scores']))
+            for index, score in enumerate(answer.scores):
+                self.assertEqual(score.rank, rv.json['scores'][index]['rank'])
+                self.assertFalse('normalized_score' in rv.json['scores'][index])
 
         # test authorized teaching assistant
         with self.login(self.fixtures.ta.username):
@@ -350,6 +362,10 @@ class AnswersAPITests(ACJAPITestCase):
             self.assertEqual(assignment_id, rv.json['assignment_id'])
             self.assertEqual(answer.user_id, rv.json['user_id'])
             self.assertEqual(answer.content, rv.json['content'])
+            self.assertEqual(len(answer.scores), len(rv.json['scores']))
+            for index, score in enumerate(answer.scores):
+                self.assertFalse('rank' in rv.json['scores'][index])
+                self.assertEqual(int(score.normalized_score), rv.json['scores'][index]['normalized_score'])
 
         # test authorized instructor
         with self.login(self.fixtures.instructor.username):
@@ -358,6 +374,10 @@ class AnswersAPITests(ACJAPITestCase):
             self.assertEqual(assignment_id, rv.json['assignment_id'])
             self.assertEqual(answer.user_id, rv.json['user_id'])
             self.assertEqual(answer.content, rv.json['content'])
+            self.assertEqual(len(answer.scores), len(rv.json['scores']))
+            for index, score in enumerate(answer.scores):
+                self.assertFalse('rank' in rv.json['scores'][index])
+                self.assertEqual(int(score.normalized_score), rv.json['scores'][index]['normalized_score'])
 
     def test_edit_answer(self):
         assignment_id = self.fixtures.assignments[0].id
@@ -513,6 +533,10 @@ class AnswersAPITests(ACJAPITestCase):
             self.assertEqual(1, len(rv.json['objects']))
             self.assertEqual(answer.id, rv.json['objects'][0]['id'])
             self.assertEqual(answer.content, rv.json['objects'][0]['content'])
+            self.assertEqual(len(answer.scores), len(rv.json['objects'][0]['scores']))
+            for index, score in enumerate(answer.scores):
+                self.assertEqual(score.rank, rv.json['objects'][0]['scores'][index]['rank'])
+                self.assertFalse('normalized_score' in rv.json['objects'][0]['scores'][index])
 
         with self.login(self.fixtures.instructor.username):
             rv = self.client.get(url)


### PR DESCRIPTION
The scores returned by api calls now return the score's rank number (by criteria) for restricted users
It also now only exposes normalized scores to none-restricted users

Fixes #51