### PR TITLE
Fix #210, #217 Session and Navbar refresh

### DIFF
--- a/acj/static/modules/authentication/authentication-service.js
+++ b/acj/static/modules/authentication/authentication-service.js
@@ -12,10 +12,13 @@ var module = angular.module(
 module.factory('AuthenticationService',
 	["$rootScope", "$resource", "$log", "$http", "$q", "authService", "Session",
 	function ($rootScope, $resource, $log, $http, $q, authService, Session) {
+        var LOGIN_EVENT = "event:Authentication-Login";
+        var LOGOUT_EVENT = "event:Authentication-Logout";
+
 		return {
 			// Use these constants to listen to login or logout events.
-			LOGIN_EVENT: "event:Authentication-Login",
-			LOGOUT_EVENT: "event:Authentication-Logout",
+			LOGIN_EVENT: LOGIN_EVENT,
+			LOGOUT_EVENT: LOGOUT_EVENT,
 			LOGIN_REQUIRED_EVENT: "event:auth-loginRequired",
 			LOGIN_FORBIDDEN_EVENT: "event:auth-forbidden",
 			isAuthenticated: function() {
@@ -28,14 +31,15 @@ module.factory('AuthenticationService',
                 });
 			},
 			login: function () {
+                Session.destroy();
                 return Session.getUser().then(function() {
                     authService.loginConfirmed();
-                    $rootScope.$broadcast(this.LOGIN_EVENT);
+                    $rootScope.$broadcast(LOGIN_EVENT);
                 });
 			},
 			logout: function() {
                 Session.destroy();
-				$rootScope.$broadcast(this.LOGOUT_EVENT);
+				$rootScope.$broadcast(LOGOUT_EVENT);
 			}
 		};
 	}

--- a/acj/static/modules/course/course-module.js
+++ b/acj/static/modules/course/course-module.js
@@ -224,7 +224,7 @@ module.controller(
 			CourseResource.save({id: $scope.course.id}, $scope.course, function (ret) {
 				Toaster.success(messages[$scope.method].title, messages[$scope.method].msg);
 				// refresh permissions
-				Session.refresh();
+				Session.refreshPermissions();
 				$location.path('/course/' + ret.id);
 			}).$promise.finally(function() {
 				$scope.submitted = false;

--- a/acj/static/modules/home/home-module.js
+++ b/acj/static/modules/home/home-module.js
@@ -34,8 +34,6 @@ module.controller(
             $scope.canAddCourse = canAddCourse;
         });
         Session.getUser().then(function(user) {
-            //TODO: why do we need a LOGIN_EVENT here?
-            $rootScope.$broadcast(AuthenticationService.LOGIN_EVENT);
             UserResource.getUserCourses(
                 {id: user.id}).$promise.then(
                 function(ret) {

--- a/acj/static/modules/navbar/navbar-module.js
+++ b/acj/static/modules/navbar/navbar-module.js
@@ -78,6 +78,9 @@ module.controller(
 		$scope.$on(AuthenticationService.LOGIN_EVENT, function() {
 		   $scope.getPermissions();
 		});
+		$scope.$on(Session.PERMISSION_REFRESHED_EVENT, function() {
+		   $scope.getPermissions();
+		});
 
 		// listen for changes in authentication state
 //		$scope.$on(AuthenticationService.LOGIN_EVENT, updateAuthentication);

--- a/acj/static/modules/user/user-module.js
+++ b/acj/static/modules/user/user-module.js
@@ -70,6 +70,12 @@ module.controller("UserController", ['$scope', '$log', '$route', '$routeParams',
 			$scope.submitted = true;
 			UserResource.save({'id': userId}, $scope.user, function(ret) {
 				Toaster.success(messages[$scope.method].title, messages[$scope.method].msg);
+                Session.getUser().then(function(user) {
+                    // refresh User's info on editing own profile and displaynmae changed
+                    if (userId == user.id && $scope.user.displayname != user.displayname) {
+                        Session.refresh();
+                    }
+                });
 				$location.path('/user/' + ret.id);
 			}).$promise.finally(function() {
 				$scope.submitted = false;


### PR DESCRIPTION
Navbar now properly refreshes on login event, permissions refresh, and session refresh (display name changes)