### PR TITLE
Add deadline timer to comparison screen

### DIFF
--- a/acj/api/comparison.py
+++ b/acj/api/comparison.py
@@ -45,6 +45,9 @@ on_comparison_update = event.signal('COMPARISON_UPDATE')
 on_assignment_comparison_count = event.signal('ASSIGNMENT_COMPARISON_COUNT')
 on_course_comparison_count = event.signal('COURSE_COMPARISON_COUNT')
 
+#messages
+comparison_deadline_message = 'Assignment comparison deadline has passed.'
+
 # /
 class CompareRootAPI(Resource):
     @login_required
@@ -57,8 +60,8 @@ class CompareRootAPI(Resource):
         require(READ, assignment)
         restrict_user = not allow(MANAGE, assignment)
 
-        if not assignment.compare_period:
-            return {'error': 'Evaluation period is not active.'}, 403
+        if not assignment.compare_grace:
+            return {'error': comparison_deadline_message}, 403
 
         # check if user has comparisons they have not completed yet
         comparisons = Comparison.query \
@@ -106,8 +109,9 @@ class CompareRootAPI(Resource):
         Course.get_active_or_404(course_id)
         assignment = Assignment.get_active_or_404(assignment_id)
 
-        if not assignment.compare_period:
-            return {'error': 'Evaluation period is not active.'}, 403
+        if not assignment.compare_grace:
+            return {'error': comparison_deadline_message}, 403
+
         require(READ, assignment)
         require(CREATE, Comparison)
         restrict_user = not allow(MANAGE, assignment)

--- a/acj/models/assignment.py
+++ b/acj/models/assignment.py
@@ -109,6 +109,17 @@ class Assignment(DefaultTableMixin, ActiveMixin, WriteTrackingMixin):
             return self.compare_start.replace(tzinfo=pytz.utc) <= now < self.compare_end.replace(tzinfo=pytz.utc)
 
     @hybrid_property
+    def compare_grace(self):
+        now = dateutil.parser.parse(datetime.datetime.utcnow().replace(tzinfo=pytz.utc).isoformat())
+        if self.compare_start and self.compare_end:
+            grace = self.compare_end.replace(tzinfo=pytz.utc) + datetime.timedelta(seconds=60)  # add 60 seconds
+            compare_start = self.compare_start.replace(tzinfo=pytz.utc)
+            return compare_start <= now < grace
+        else:
+            answer_end = self.answer_end.replace(tzinfo=pytz.utc)
+            return now >= answer_end
+
+    @hybrid_property
     def after_comparing(self):
         now = dateutil.parser.parse(datetime.datetime.utcnow().replace(tzinfo=pytz.utc).isoformat())
         answer_end = self.answer_end.replace(tzinfo=pytz.utc)

--- a/acj/static/modules/comparison/comparison-core.html
+++ b/acj/static/modules/comparison/comparison-core.html
@@ -24,6 +24,14 @@
 
 		<hr />
 
+        <div class="h3 text-center" ng-show="showCountDown && !comparisonsError">
+            <timer end-time="assignment.compare_end">
+                <span title="Official time remaining until deadline" class="bg-danger alert text-danger">{{minutes}} minutes {{seconds}} seconds left</span>
+            </timer>
+            <br /><br />
+            <span class="h4">(Comparison must be saved by deadline to be accepted)</span>
+        </div>
+
 		<h2 class="col-md-6">Answer Pair</h2>
 		<h2 class="col-md-6 text-right rounds"><span ng-hide="comparisonsError" class="label label-warning">Round {{current}} / {{total}}</span></h2>
 

--- a/acj/static/modules/comparison/comparison-module_spec.js
+++ b/acj/static/modules/comparison/comparison-module_spec.js
@@ -297,6 +297,10 @@ describe('comparison-module', function () {
 			"user_id": 1
 		}];
 
+        var mockTimer = {
+            "date": 1467325647825
+        }
+
 		beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$modal_, _$q_) {
 			$rootScope = _$rootScope_;
 			$location = _$location_;
@@ -319,6 +323,8 @@ describe('comparison-module', function () {
 			$httpBackend.expectGET('/api/courses/3/assignments/9/comparisons').respond({
                 'objects':mockComparisons
             });
+			$httpBackend.expectGET('/api/timer').respond(mockTimer);
+
 			$httpBackend.expectGET('/api/courses/3/assignments/9/answer_comments?answer_ids=279,407&evaluation=only&user_ids=1').respond(mockComments);
 			createController({}, {courseId:3, assignmentId:9});
 			expect($rootScope.assignment).toEqual({});
@@ -355,6 +361,7 @@ describe('comparison-module', function () {
                 $httpBackend.expectGET('/api/courses/3/assignments/9/comparisons').respond({
                     'objects':mockComparisons
                 });
+			    $httpBackend.expectGET('/api/timer').respond(mockTimer);
 				$httpBackend.whenGET('/api/courses/3/assignments/9/answer_comments?answer_ids=279,407&evaluation=only&user_ids=1').respond(mockComments);
 				$mockRoute = jasmine.createSpyObj('route', ['reload']);
 				controller = createController($mockRoute, {courseId:3, assignmentId:9});


### PR DESCRIPTION
Comparison deadline timer works similarly to the answer deadline timer.
Added a comparison grace period similar to the answer grace period.
Added backend unit tests for both answer and comparison grace periods.

Related #179