### PR TITLE
Add answer & answer comment drafts

### DIFF
--- a/acj/api/comparison.py
+++ b/acj/api/comparison.py
@@ -134,6 +134,10 @@ class CompareRootAPI(Resource):
 
         # check if each comparison has a criterion Id and a winner id
         for comparison_to_update in params['comparisons']:
+            # check if saving a draft
+            if 'draft' in comparison_to_update and comparison_to_update['draft']:
+                completed = False
+
             # ensure criterion param is present
             if 'criterion_id' not in comparison_to_update:
                 return {"error": "Missing criterion_id in evaluation."}, 400
@@ -154,7 +158,7 @@ class CompareRootAPI(Resource):
                     known_criterion = True
 
                     # check that the winner id matches one of the answer pairs
-                    if winner_id != comparison.answer1_id and winner_id != comparison.answer2_id:
+                    if winner_id not in [comparison.answer1_id, comparison.answer2_id, None]:
                         return {"error": "Selected answer does not match the available answers in comparison."}, 400
 
                     break

--- a/acj/api/dataformat/__init__.py
+++ b/acj/api/dataformat/__init__.py
@@ -137,6 +137,7 @@ def get_answer(restrict_user=True):
         'content': fields.String,
         'file': fields.Nested(get_file(), allow_null=True),
         'flagged': fields.Boolean,
+        'draft': fields.Boolean,
 
         'scores': fields.List(fields.Nested(get_score(
             restrict_user=restrict_user
@@ -176,6 +177,7 @@ def get_answer_comment(restrict_user=True):
         'user_id': fields.Integer,
         'content': fields.String,
         'comment_type': UnwrapAnswerCommentType(attribute='comment_type'),
+        'draft': fields.Boolean,
 
         'user': get_partial_user(restrict_user),
         'created': fields.DateTime,

--- a/acj/api/gradebook.py
+++ b/acj/api/gradebook.py
@@ -75,6 +75,7 @@ class GradebookAPI(Resource):
                 Answer.id == Score.answer_id,
                 Score.criterion_id.in_(criterion_ids))). \
             filter(Answer.assignment_id == assignment_id). \
+            filter(Answer.draft == False). \
             subquery()
 
         scores_by_user = User.query. \
@@ -107,6 +108,7 @@ class GradebookAPI(Resource):
             stmt = AnswerComment.query \
                 .with_entities(AnswerComment.user_id, func.count('*').label('comment_count')) \
                 .filter_by(comment_type=AnswerCommentType.self_evaluation) \
+                .filter_by(draft=False) \
                 .join(Answer, and_(
                     Answer.id == AnswerComment.answer_id,
                     Answer.assignment_id == assignment_id)) \

--- a/acj/api/report.py
+++ b/acj/api/report.py
@@ -160,6 +160,7 @@ def participation_stat_report(course_id, assignments, group_name, overall):
         answers = Answer.query \
             .filter_by(active=True) \
             .filter_by(assignment_id=assignment.id) \
+            .filter_by(draft=False) \
             .all()
         answers = {a.user_id: a.id for a in answers}
 
@@ -175,6 +176,7 @@ def participation_stat_report(course_id, assignments, group_name, overall):
         comments = AnswerComment.query \
             .join(Answer) \
             .filter(Answer.assignment_id == assignment.id) \
+            .filter(AnswerComment.draft == False) \
             .with_entities(AnswerComment.user_id, func.count(AnswerComment.id)) \
             .group_by(AnswerComment.user_id) \
             .all()
@@ -249,6 +251,7 @@ def participation_report(course_id, assignments, group_name):
     answers = Answer.query \
         .filter(Answer.assignment_id.in_(assignment_ids)) \
         .filter(Answer.user_id.in_(user_ids)) \
+        .filter(Answer.draft == False) \
         .all()
 
     scores = {}  # structure - user_id/assignment_id/criterion_id/normalized_score
@@ -290,6 +293,7 @@ def participation_report(course_id, assignments, group_name):
         .join(Answer) \
         .filter(Answer.assignment_id.in_(assignment_ids)) \
         .filter(AnswerComment.user_id.in_(user_ids)) \
+        .filter(AnswerComment.draft == False) \
         .with_entities(Answer.assignment_id, AnswerComment.user_id, func.count(AnswerComment.id)) \
         .group_by(Answer.assignment_id, AnswerComment.user_id) \
         .all()

--- a/acj/authorization.py
+++ b/acj/authorization.py
@@ -72,13 +72,17 @@ def define_authorization(user, they):
             continue
         they.can(READ, Course, id=entry.course_id)
         they.can(READ, Assignment, course_id=entry.course_id)
-        they.can((READ, CREATE), Answer, course_id=entry.course_id)
-        they.can((EDIT, DELETE), Answer, user_id=user.id)
+        # only owner/Instructors/TAs can read answer drafts
+        they.can(READ, Answer, course_id=entry.course_id, draft=False)
+        they.can(CREATE, Answer, course_id=entry.course_id)
+        they.can((EDIT, DELETE, READ), Answer, user_id=user.id)
         they.can((READ, CREATE), AssignmentComment, course_id=entry.course_id)
         they.can((EDIT, DELETE), AssignmentComment, user_id=user.id)
-        they.can((READ, CREATE), AnswerComment, course_id=entry.course_id)
+        # only owner/Instructors/TAs can read answer comment drafts
+        they.can(READ, AnswerComment, course_id=entry.course_id, draft=False)
+        they.can(CREATE, AnswerComment, course_id=entry.course_id)
         # owner of the answer comment
-        they.can((EDIT, DELETE), AnswerComment, user_id=user.id)
+        they.can((EDIT, DELETE, READ), AnswerComment, user_id=user.id)
         # instructors can modify the course and enrolment
         if entry.course_role == CourseRole.instructor:
             they.can(EDIT, Course, id=entry.course_id)

--- a/acj/manage/report.py
+++ b/acj/manage/report.py
@@ -30,6 +30,7 @@ def create(course_id):
         join(Score.answer). \
         join(Answer). \
         join(Score.criterion). \
+        filter(Answer.draft == False). \
         order_by(Answer.assignment_id, Criterion.id, Answer.user_id)
 
     if course_id:

--- a/acj/models/answer.py
+++ b/acj/models/answer.py
@@ -22,6 +22,7 @@ class Answer(DefaultTableMixin, ActiveMixin, WriteTrackingMixin):
     flagged = db.Column(db.Boolean(name='flagged'), default=False, nullable=False)
     flagger_user_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete="SET NULL"),
         nullable=True)
+    draft = db.Column(db.Boolean(name='draft'), default=False, nullable=False)
 
     # relationships
     # assignment via Assignment Model
@@ -51,7 +52,8 @@ class Answer(DefaultTableMixin, ActiveMixin, WriteTrackingMixin):
             select([func.count(AnswerComment.id)]).
             where(and_(
                 AnswerComment.answer_id == cls.id,
-                AnswerComment.active == True
+                AnswerComment.active == True,
+                AnswerComment.draft == False
             )),
             deferred=True,
             group='counts'
@@ -62,6 +64,7 @@ class Answer(DefaultTableMixin, ActiveMixin, WriteTrackingMixin):
             where(and_(
                 AnswerComment.answer_id == cls.id,
                 AnswerComment.active == True,
+                AnswerComment.draft == False,
                 AnswerComment.comment_type == AnswerCommentType.public
             )),
             deferred=True,
@@ -73,6 +76,7 @@ class Answer(DefaultTableMixin, ActiveMixin, WriteTrackingMixin):
             where(and_(
                 AnswerComment.comment_type == AnswerCommentType.self_evaluation,
                 AnswerComment.active == True,
+                AnswerComment.draft == False,
                 AnswerComment.answer_id == cls.id
             )),
             deferred=True,

--- a/acj/models/answer_comment.py
+++ b/acj/models/answer_comment.py
@@ -20,6 +20,7 @@ class AnswerComment(DefaultTableMixin, ActiveMixin, WriteTrackingMixin):
     content = db.Column(db.Text)
     comment_type = db.Column(EnumType(AnswerCommentType, name="comment_type"),
         nullable=False, index=True)
+    draft = db.Column(db.Boolean(name='draft'), default=False, nullable=False)
 
     # relationships
     # answer via Answer Model

--- a/acj/models/assignment.py
+++ b/acj/models/assignment.py
@@ -149,7 +149,8 @@ class Assignment(DefaultTableMixin, ActiveMixin, WriteTrackingMixin):
             select([func.count(Answer.id)]).
             where(and_(
                 Answer.assignment_id == cls.id,
-                Answer.active == True
+                Answer.active == True,
+                Answer.draft == False
             )),
             deferred=True,
             group="counts"
@@ -188,6 +189,7 @@ class Assignment(DefaultTableMixin, ActiveMixin, WriteTrackingMixin):
                 AnswerComment.comment_type == AnswerCommentType.self_evaluation,
                 AnswerComment.active == True,
                 AnswerComment.answer_id == Answer.id,
+                AnswerComment.draft == False,
                 Answer.assignment_id == cls.id
             )),
             deferred=True,

--- a/acj/models/comparison.py
+++ b/acj/models/comparison.py
@@ -84,7 +84,9 @@ class Comparison(DefaultTableMixin, WriteTrackingMixin):
         eligible_answers = Answer.query \
             .filter(and_(
                 Answer.assignment_id == assignment_id,
-                Answer.user_id.notin_(ineligible_user_ids)
+                Answer.user_id.notin_(ineligible_user_ids),
+                Answer.draft == False,
+                Answer.active == True
             )) \
             .count()
         return eligible_answers / 2 >= 1  # min 1 pair required
@@ -115,7 +117,8 @@ class Comparison(DefaultTableMixin, WriteTrackingMixin):
             .filter(and_(
                 Answer.user_id.notin_(ineligible_user_ids),
                 Answer.assignment_id == assignment_id,
-                Answer.active == True
+                Answer.active == True,
+                Answer.draft == False
             )) \
             .group_by(Answer.id)
 

--- a/acj/static/acj-config.js
+++ b/acj/static/acj-config.js
@@ -135,12 +135,14 @@ myApp.config(['$routeProvider', '$logProvider', '$httpProvider', function ($rout
 		.when ('/course/:courseId/assignment/:assignmentId/answer/create',
 			{
 				templateUrl: 'modules/answer/answer-create-partial.html',
-				label: "Answer"
+				label: "Answer",
+				method: 'new'
 			})
 		.when ('/course/:courseId/assignment/:assignmentId/answer/:answerId/edit',
 			{
 				templateUrl: 'modules/answer/answer-edit-partial.html',
-				label: "Edit Answer"
+				label: "Edit Answer",
+				method: 'edit'
 			})
 		.when ('/course/:courseId/assignment/:assignmentId/comment/create',
 			{

--- a/acj/static/modules/answer/answer-create-partial.html
+++ b/acj/static/modules/answer/answer-create-partial.html
@@ -1,4 +1,4 @@
-<div ng-controller="AnswerCreateController">
+<div ng-controller="AnswerWriteController">
 	<h1>Answer</h1>
 	<ng-include src="'modules/answer/answer-form-partial.html'"></ng-include>
 </div>

--- a/acj/static/modules/answer/answer-edit-partial.html
+++ b/acj/static/modules/answer/answer-edit-partial.html
@@ -1,4 +1,4 @@
-<div ng-controller="AnswerEditController">
+<div ng-controller="AnswerWriteController">
 	<h1>Edit Answer</h1>
 	<ng-include src="'modules/answer/answer-form-partial.html'"></ng-include>
 </div>

--- a/acj/static/modules/answer/answer-form-partial.html
+++ b/acj/static/modules/answer/answer-form-partial.html
@@ -21,7 +21,7 @@
 			<span class="h4">(Answer must be saved by deadline to be accepted)</span>
 		</div>
 
-		<div class="form-group" ng-if="canManageAssignment && create">
+		<div class="form-group" ng-if="canManageAssignment && showUserList">
 			<label for="user_id">Submit As</label>
 			<select id="user_id" name="user_id" ng-model="answer.user_id"  class="form-control" required
 					ng-options="u.id as u.fullname for u in classlist">
@@ -66,6 +66,20 @@
 			</textarea>
 		</div>
 	</fieldset>
-	<input type="submit" class="btn btn-success btn-lg center-block" value="Save"
-		ng-disabled="answerForm.$invalid || submitted || (uploader.queue.length && !uploader.queue[0].isSuccess)" />
+    <div class="row" ng-show="answer.draft">
+        <div class="col-md-3 col-md-offset-3 col-xs-6">
+            <input type="submit" class="btn btn-success btn-lg center-block" value="Save Draft"
+                ng-click="answer.draft = true"
+                ng-disabled="submitted || (uploader.queue.length && !uploader.queue[0].isSuccess)" />
+        </div>
+        <div class="col-md-3 col-xs-6">
+            <input type="submit" class="btn btn-success btn-lg center-block" value="Submit Answer"
+                ng-click="answer.draft = false"
+                ng-disabled="answerForm.$invalid || submitted || (uploader.queue.length && !uploader.queue[0].isSuccess)" />
+        </div>
+    </div>
+    <div ng-show="!answer.draft">
+        <input type="submit" class="btn btn-success btn-lg center-block" value="Save"
+            ng-disabled="answerForm.$invalid || submitted || (uploader.queue.length && !uploader.queue[0].isSuccess)" />
+    </div>
 </form>

--- a/acj/static/modules/assignment/assignment-module.js
+++ b/acj/static/modules/assignment/assignment-module.js
@@ -346,12 +346,12 @@ module.controller("AssignmentViewController",
                         function (ret) {
                             $scope.assignment.status = ret.status;
 
-                            var comparisons_count = $scope.assignment.status.comparisons.count;
+                            var comparisons_count = ret.status.comparisons.count;
                             $scope.compared_req_met = comparisons_count >= $scope.assignment.number_of_comparisons;
 
                             $scope.evaluation = 0;
                             if (!$scope.compared_req_met) {
-                                $scope.evaluation = $scope.assignment.number_of_comparisons - comparisons_count;
+                                $scope.evaluation = ret.status.comparisons.left;
                             }
                             // if evaluation period is set answers can be seen after it ends
                             if ($scope.assignment.compare_end) {
@@ -360,24 +360,19 @@ module.controller("AssignmentViewController",
                             } else {
                                 $scope.see_answers = $scope.assignment.after_comparing && $scope.compared_req_met;
                             }
-                            var diff = $scope.assignment.answer_count - $scope.assignment.status.answers.count;
+                            var diff = $scope.assignment.answer_count - ret.status.answers.count;
                             var evaluation_left = ((diff * (diff - 1)) / 2);
-                            $scope.warning = ($scope.assignment.number_of_comparisons - comparisons_count) > evaluation_left;
+                            $scope.warning = ret.status.comparisons.left > evaluation_left;
+
+                            if ($scope.assignment.enable_self_evaluation) {
+                                $scope.self_evaluation_req_met = ret.status.comparisons.self_evauluation_completed;
+                                $scope.self_evaluation = $scope.self_evaluation_req_met ? 0 : 1;
+                            }
                         },
                         function (ret) {
                             Toaster.reqerror("Assignment Status Not Found", ret);
                         }
                     );
-
-                    // get the self evaluation if enabled in assignment
-                    if ($scope.assignment.enable_self_evaluation) {
-                        AnswerCommentResource.query(angular.extend({}, params, {user_ids: $scope.loggedInUserId, self_evaluation: 'only'}),
-                            function (ret) {
-                                $scope.self_evaluation_req_met = ret.length > 0;
-                                $scope.self_evaluation = 1 - ret.length;
-                            }
-                        );
-                    }
                     // update the answer list
                     $scope.updateAnswerList();
                     // register watcher here so that we start watching when all filter values are set

--- a/acj/static/modules/assignment/assignment-module_spec.js
+++ b/acj/static/modules/assignment/assignment-module_spec.js
@@ -685,15 +685,18 @@ describe('course-module', function () {
                     "status": {
                         "answers": {
                             "answered": true,
-                            "count": 1
+                            "count": 1,
+                            "draft_ids": [],
+                            "has_draft": true
                         },
                         "comparisons": {
                             "available": false,
-                            "count": 0
+                            "count": 0,
+                            "left": 3,
+                            "self_evauluation_completed": false
                         }
                     }
                 });
-                $httpBackend.expectGET('/api/courses/1/assignments/1/answer_comments?self_evaluation=only&user_ids='+id).respond([]);
                 $httpBackend.expectGET('/api/courses/1/assignments/1/answers?orderBy=1&page=1&perPage=20').respond(mockAnswers);
                 $httpBackend.flush();
             });

--- a/acj/static/modules/assignment/assignment-view-partial.html
+++ b/acj/static/modules/assignment/assignment-view-partial.html
@@ -59,10 +59,16 @@
 
 		<!-- Assignment Actions -->
 
-		<!-- BUTTON when user is admin OR (user has not answered AND the answer period is active) -->
+        <!-- BUTTON when user does not have an answer draft AND (user is admin OR (user has not answered AND the answer period is active) -->
 		<a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/answer/create" class="btn btn-success" title="Answer Assignment"
-		   ng-show="canManageAssignment || (!assignment.status.answers.answered && assignment.answer_period)">
+		   ng-show="!assignment.status.answers.has_draft && (canManageAssignment || (!assignment.status.answers.answered && assignment.answer_period))">
 			Answer
+		</a>
+
+        <!-- BUTTON when user has an answer draft AND (user is admin OR (user has not answered AND the answer period is active) -->
+		<a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/answer/{{assignment.status.answers.draft_ids[0]}}/edit" class="btn btn-success" title="Answer Assignment"
+		   ng-show="assignment.status.answers.has_draft && (canManageAssignment || (!assignment.status.answers.answered && assignment.answer_period))">
+			Finish Answering
 		</a>
 
 		<!-- BUTTON when user is not an admin AND the comparison period is active AND the user has not finished pair comparisons AND either (the answer period is active AND the assignment has been answered) OR (the answer period is not active)
@@ -178,7 +184,7 @@
 
 				<!-- Students should see before evaluating during the evaluation period (self-evaluation) -->
 				<p class="intro-text" ng-if="!canManageAssignment && assignment.compare_period && compared_req_met && !self_evaluation_req_met">
-					<a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/comparison" title="Compare answers">Compare your answer</a> for the assignment first, then read answers written by your classmates and instructors here.
+					<a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/compare" title="Compare answers">Compare your answer</a> for the assignment first, then read answers written by your classmates and instructors here.
 				</p>
 
 				<!-- Anyone sees during the answer period, if no answers provided yet -->

--- a/acj/static/modules/comment/comment-form-partial.html
+++ b/acj/static/modules/comment/comment-form-partial.html
@@ -21,6 +21,21 @@
             <label for="comment_type">Show this reply to the whole class</label>
 		</div>
 	</fieldset>
-	<input type="submit" class="btn btn-success btn-lg center-block" value="Save"
-		ng-disabled="commentForm.$invalid || submitted" />
+
+    <div class="row" ng-show="comment.draft">
+        <div class="col-md-3 col-md-offset-3 col-xs-6">
+            <input type="submit" class="btn btn-success btn-lg center-block" value="Save Draft"
+                ng-click="comment.draft = true"
+                ng-disabled="submitted" />
+        </div>
+        <div class="col-md-3 col-xs-6">
+            <input type="submit" class="btn btn-success btn-lg center-block" value="Save"
+                ng-click="comment.draft = false"
+                ng-disabled="commentForm.$invalid || submitted" />
+        </div>
+    </div>
+    <div ng-show="!comment.draft">
+        <input type="submit" class="btn btn-success btn-lg center-block" value="Save"
+            ng-disabled="commentForm.$invalid || submitted" />
+    </div>
 </form>

--- a/acj/static/modules/comparison/comparison-core.html
+++ b/acj/static/modules/comparison/comparison-core.html
@@ -187,16 +187,24 @@
 			</div>
 
 			<div class="form-group sub-step">
-				<!-- button to submit and refresh page IF evaluations remain for user -->
-				<input ng-disabled="comparisonForm.$invalid || submitted" type="submit"
-					value="Submit" class="btn btn-success btn-lg center-block" />
+                <div class="row">
+                    <div class="col-md-3 col-md-offset-3 col-xs-6">
+                        <input ng-disabled="submitted" type="submit"
+                            ng-click="$parent.isDraft = true"
+                            value="Save Draft" class="btn btn-success btn-lg center-block" />
+                    </div>
+                    <div class="col-md-3 col-xs-6">
+                        <!-- button to submit and refresh page IF evaluations remain for user -->
+                        <input ng-disabled="comparisonForm.$invalid || submitted" type="submit"
+                            ng-click="$parent.isDraft = false"
+                            value="Submit" class="btn btn-success btn-lg center-block" />
+                    </div>
+                </div>
 				<p ng-if="submitted" class="text-center" >
 					<i class="fa fa-spin fa-spinner"></i>
 					&nbsp; Saving comparison...
 				</p>
-
 			</div>
-
 
 		</div>
 

--- a/acj/static/modules/course/course-assignments-partial.html
+++ b/acj/static/modules/course/course-assignments-partial.html
@@ -129,7 +129,7 @@
 					<!-- Completed Assignment Feedback (for students) -->
 					<li ng-if="!canManageAssignment && ((assignment.left + assignment.self_evaluation_left == 0) || assignment.status.answers.answered)">
 						You
-						<span ng-if="answered"><strong>assignment.status.answers.answered</strong> <span ng-if="assignment.left + assignment.self_evaluation_left == 0">and </span></span>
+						<span ng-if="answered"><strong>answered</strong> <span ng-if="assignment.left + assignment.self_evaluation_left == 0">and </span></span>
 						<span ng-if="assignment.left + assignment.self_evaluation_left == 0"><strong>compared</strong></span>
 					</li>
 					<!-- Pending Assignment Feedback (for students) -->
@@ -158,11 +158,17 @@
 		<!-- Assignment Actions -->
 		<div class="col-sm-3 text-right action-btns">
 
-			<!-- BUTTON when user is admin OR (user has not answered AND the answer period is active) -->
-			<a class="btn btn-success" title="Answer Assignment" ng-href="#/course/{{course.id}}/assignment/{{assignment.id}}/answer/create"
-			   ng-show="canManageAssignment || (!assignment.status.answers.answered && assignment.answer_period)">
-				Answer
-			</a>
+            <!-- BUTTON when user does not have an answer draft AND (user is admin OR (user has not answered AND the answer period is active) -->
+            <a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/answer/create" class="btn btn-success" title="Answer Assignment"
+            ng-show="!assignment.status.answers.has_draft && (canManageAssignment || (!assignment.status.answers.answered && assignment.answer_period))">
+                Answer
+            </a>
+
+            <!-- BUTTON when user has an answer draft AND (user is admin OR (user has not answered AND the answer period is active) -->
+            <a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/answer/{{assignment.status.answers.draft_ids[0]}}/edit" class="btn btn-success" title="Answer Assignment"
+            ng-show="assignment.status.answers.has_draft && (canManageAssignment || (!assignment.status.answers.answered && assignment.answer_period))">
+                Finish Answer
+            </a>
 
 			<!-- BUTTON when user is not an admin AND the comparison period is active AND the user has not finished pair comparisons AND either (the answer period is active AND the assignment has been answered) OR (the answer period is not active)
 			     basically we force users to answer first, if they can

--- a/acj/static/modules/course/course-module.js
+++ b/acj/static/modules/course/course-module.js
@@ -96,25 +96,25 @@ module.controller(
 
                             // comparison count
 							var required = assignment.number_of_comparisons;
-							assignment['left'] = assignment.status.comparisons.count <= required ?
-								required - assignment.status.comparisons.count : 0;
+							assignment.left = assignment.status.comparisons.left;
+
 							// if evaluation period is set answers can be seen after it ends
-							if (assignment['compare_end']) {
-								assignment['answers_available'] = assignment['after_comparing'];
+							if (assignment.compare_end) {
+								assignment.answers_available = assignment.after_comparing;
 							// if an evaluation period is NOT set - answers can be seen after req met
 							} else {
-								assignment['answers_available'] = assignment['after_comparing'] && assignment['left'] < 1;
+								assignment.answers_available = assignment.after_comparing && assignment.left < 1;
 							}
 
                             // comparison available
-                            assignment['self_evaluation_left'] = 0;
+                            assignment.self_evaluation_left = 0;
                             /*
                             Assumptions made:
                             - only one self-evaluation type per assignment
                             - if self-evaluation is required but not one is submitted --> 1 needs to be completed
                             */
-                            if (assignment.enable_self_evaluation && !assignment.status.comparisons.available) {
-                                assignment['self_evaluation_left'] = 1;
+                            if (assignment.enable_self_evaluation && !assignment.status.comparisons.self_evauluation_completed) {
+                                assignment.self_evaluation_left = 1;
                             }
 						}
 					},

--- a/acj/static/test/factories/http_backend_mocks.js
+++ b/acj/static/test/factories/http_backend_mocks.js
@@ -406,11 +406,14 @@ module.exports.httpbackendMock = function(storageFixture) {
                     statuses[assignmentId] = {
                         "answers": {
                             "answered": false,
-                            "count": 0
+                            "count": 0,
+                            "draft_ids": [],
+                            "has_draft": true
                         },
                         "comparisons": {
                             "available": true,
-                            "count": 0
+                            "count": 0,
+                            "left": 3
                         }
                     }
                 });
@@ -575,11 +578,14 @@ module.exports.httpbackendMock = function(storageFixture) {
             status = {
                 "answers": {
                     "answered": false,
-                    "count": 0
+                    "count": 0,
+                    "draft_ids": [],
+                    "has_draft": true
                 },
                 "comparisons": {
                     "available": true,
-                    "count": 0
+                    "count": 0,
+                    "left": 3
                 }
             }
 

--- a/acj/tests/api/test_report.py
+++ b/acj/tests/api/test_report.py
@@ -11,7 +11,8 @@ from flask import current_app
 class ReportAPITest(ACJAPITestCase):
     def setUp(self):
         super(ReportAPITest, self).setUp()
-        self.fixtures = TestFixture().add_course(num_students=30, num_assignments=2, num_groups=2, num_answers=25)
+        self.fixtures = TestFixture().add_course(num_students=30, num_assignments=2, num_groups=2, num_answers=25,
+            with_draft_student=True)
         self.url = "/api/courses/" + str(self.fixtures.course.id) + "/report"
         self.files_to_cleanup = []
 
@@ -348,7 +349,8 @@ class ReportAPITest(ACJAPITestCase):
             answer = Answer.query \
                 .filter(
                     Answer.user_id == student.id,
-                    Answer.assignment_id == assignment.id
+                    Answer.assignment_id == assignment.id,
+                    Answer.draft == False
                 ) \
                 .first()
 
@@ -424,7 +426,8 @@ class ReportAPITest(ACJAPITestCase):
                 answer = Answer.query \
                     .filter(
                         Answer.user_id == student.id,
-                        Answer.assignment_id == assignment.id
+                        Answer.assignment_id == assignment.id,
+                        Answer.draft == False
                     ) \
                     .first()
 
@@ -437,7 +440,6 @@ class ReportAPITest(ACJAPITestCase):
                 else:
                     self.assertEqual(row[index], "No Answer")
                 index += 1
-
 
                 comparisons = Comparison.query \
                     .filter(

--- a/alembic/versions/144167b8fb35_add_draft_column_to_answer_and_answer_.py
+++ b/alembic/versions/144167b8fb35_add_draft_column_to_answer_and_answer_.py
@@ -1,0 +1,26 @@
+"""Add draft column to answer and answer_comment tables
+
+Revision ID: 144167b8fb35
+Revises: aafd2a91e3a
+Create Date: 2016-07-05 12:09:24.279648
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '144167b8fb35'
+down_revision = 'aafd2a91e3a'
+
+from alembic import op
+import sqlalchemy as sa
+
+from acj.models import convention
+
+def upgrade():
+    op.add_column('answer', sa.Column('draft', sa.Boolean(name='draft'), nullable=False, default='0', server_default='0'))
+    op.add_column('answer_comment', sa.Column('draft', sa.Boolean(name='draft'), nullable=False, default='0', server_default='0'))
+
+def downgrade():
+    with op.batch_alter_table('answer_comment', naming_convention=convention) as batch_op:
+        batch_op.drop_column('draft')
+    with op.batch_alter_table('answer', naming_convention=convention) as batch_op:
+        batch_op.drop_column('draft')

--- a/data/factories.py
+++ b/data/factories.py
@@ -91,6 +91,7 @@ class AnswerFactory(SQLAlchemyModelFactory):
     assignment_id = 1
     user_id = 1
     content = factory.Sequence(lambda n: u'this is some content for post %d' % n)
+    draft = False
     # Make sure created dates are unique.
     created = factory.Sequence(lambda n: datetime.datetime.fromtimestamp(1404768528 - n))
 
@@ -116,6 +117,7 @@ class AnswerCommentFactory(SQLAlchemyModelFactory):
     course_id = 1
     user_id = 1
     content = factory.Sequence(lambda n: u'this is some content for post %d' % n)
+    draft = False
     # Make sure created dates are unique.
     created = factory.Sequence(lambda n: datetime.datetime.fromtimestamp(1404768528 - n))
 

--- a/database_scripts/acj_users_score.sql
+++ b/database_scripts/acj_users_score.sql
@@ -15,7 +15,8 @@ FROM (
 ) as scores
 JOIN assignment_criterion as ac ON ac.id = scores.criterion_id
 JOIN criterion as c ON c.id = cq.criterion_id
-JOIN Answer AS a ON a.id = scores.answer_id
+JOIN answer AS a ON a.id = scores.answer_id
+WHERE NOT a.draft
 ORDER BY ac.id ASC, a.user_id ASC
 INTO OUTFILE '/tmp/test.csv'
 FIELDS TERMINATED BY ','


### PR DESCRIPTION
Users can save drafts for answers and answer comments without being visible to other users or effecting counters/comparisons.

Basic UI elements (save draft buttons) and success messages were added to the front-end forms but they need to be reviewed.

Related #258