### PR TITLE
Add course year & term

### DIFF
--- a/acj/api/dataformat/__init__.py
+++ b/acj/api/dataformat/__init__.py
@@ -57,21 +57,19 @@ def get_users_in_course(restrict_user=True):
 
 
 def get_course(include_details=True):
-    data_format = {
+    return {
         'id': fields.Integer,
         'name': fields.String,
+        'year': fields.Integer,
+        'term': fields.String,
+        'fullname': fields.String,
         'description': fields.String,
+        'start_date': fields.DateTime,
+        'end_date': fields.DateTime,
+        'available': fields.Boolean,
+        'modified': fields.DateTime,
+        'created': fields.DateTime
     }
-    if include_details:
-        details = {
-            'start_date': fields.DateTime,
-            'end_date': fields.DateTime,
-            'modified': fields.DateTime,
-            'created': fields.DateTime
-        }
-        data_format.update(details)
-    return data_format
-
 
 def get_criterion():
     data_format = {

--- a/acj/api/users.py
+++ b/acj/api/users.py
@@ -199,20 +199,19 @@ class UserCourseListAPI(Resource):
     def get(self, user_id):
         User.query.get_or_404(user_id)
         # we want to list courses only, so only check the association table
-        keys = dataformat.get_course(include_details=False).keys()
         if allow(MANAGE, Course):
             courses = Course.query \
-                .options(load_only(*keys)) \
-                .order_by(asc(Course.name)) \
+                .filter_by(active=True) \
+                .order_by(Course.name) \
                 .all()
         else:
             courses = Course.query \
                 .join(UserCourse) \
                 .filter(and_(
                     UserCourse.user_id == user_id,
-                    UserCourse.course_role != CourseRole.dropped
+                    UserCourse.course_role != CourseRole.dropped,
+                    Course.active == True
                 )) \
-                .options(load_only(*keys)) \
                 .order_by(Course.name) \
                 .all()
 
@@ -224,7 +223,7 @@ class UserCourseListAPI(Resource):
             user=current_user,
             data={'userid': user_id})
 
-        return {'objects': marshal(courses, dataformat.get_course(include_details=False))}
+        return {'objects': marshal(courses, dataformat.get_course())}
 
 # courses/teaching
 class TeachingUserCourseListAPI(Resource):

--- a/acj/models/course.py
+++ b/acj/models/course.py
@@ -1,3 +1,7 @@
+import dateutil.parser
+import datetime
+import pytz
+
 # sqlalchemy
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy import func, select, and_, or_
@@ -9,19 +13,36 @@ from acj.core import db
 
 class Course(DefaultTableMixin, ActiveMixin, WriteTrackingMixin):
     # table columns
-    name = db.Column(db.String(255), nullable=False, unique=True)
+    name = db.Column(db.String(255), nullable=False)
+    year = db.Column(db.Integer, nullable=False)
+    term = db.Column(db.String(255), nullable=False)
     description = db.Column(db.Text)
     start_date = db.Column(db.DateTime(timezone=True), nullable=True)
     end_date = db.Column(db.DateTime(timezone=True), nullable=True)
-
     # relationships
 
     # user many-to-many course with association user_course
     user_courses = db.relationship("UserCourse", back_populates="course", lazy="dynamic")
-
     assignments = db.relationship("Assignment", backref="course", lazy="dynamic")
 
     # hyprid and other functions
+    @hybrid_property
+    def fullname(self):
+        return '%s %s %s' % (self.name, self.term, self.year)
+
+    @hybrid_property
+    def available(self):
+        now = dateutil.parser.parse(datetime.datetime.utcnow().replace(tzinfo=pytz.utc).isoformat())
+
+        # must be after start date if set
+        if self.start_date and self.start_date.replace(tzinfo=pytz.utc) > now:
+            return False
+
+        # must be before end date if set
+        if self.end_date and now >= self.end_date.replace(tzinfo=pytz.utc):
+            return False
+
+        return True
 
     @classmethod
     def __declare_last__(cls):

--- a/acj/static/modules/assignment/assignment-module_spec.js
+++ b/acj/static/modules/assignment/assignment-module_spec.js
@@ -47,7 +47,12 @@ describe('course-module', function () {
         "description": null,
         "id": 1,
         "modified": "Fri, 09 Jan 2015 17:23:59 -0000",
-        "name": "Test Course"
+        "name": "Test Course",
+        "year": 2015,
+        "term": "Winter",
+        "fullname": "Test Course Winter 2015",
+        "start_time": null,
+        "end_time": null
     };
     var mockCritiera = {
         "objects": [

--- a/acj/static/modules/comparison/comparison-module_spec.js
+++ b/acj/static/modules/comparison/comparison-module_spec.js
@@ -47,7 +47,12 @@ describe('comparison-module', function () {
         "description": null,
         "id": 1,
         "modified": "Fri, 09 Jan 2015 17:23:59 -0000",
-        "name": "Test Course"
+        "name": "Test Course",
+        "year": 2015,
+        "term": "Winter",
+        "fullname": "Test Course Winter 2015",
+        "start_time": null,
+        "end_time": null,
     };
     beforeEach(module('ubc.ctlt.acj.comparison'));
     beforeEach(inject(function ($injector) {

--- a/acj/static/modules/course/course-module.js
+++ b/acj/static/modules/course/course-module.js
@@ -184,6 +184,10 @@ module.controller(
             edit: {title: 'Course Successfully Updated', msg: 'Your course changes have been saved.'}
         };
 
+        self['new'] = function() {
+            $scope.course.year = new Date().getFullYear();
+        };
+
         self.edit = function() {
             $scope.courseId = $routeParams['courseId'];
             $scope.course = CourseResource.get({'id':$scope.courseId});

--- a/acj/static/modules/course/course-module_spec.js
+++ b/acj/static/modules/course/course-module_spec.js
@@ -47,7 +47,10 @@ describe('course-module', function () {
         "description": null,
         "id": 1,
         "modified": "Fri, 09 Jan 2015 17:23:59 -0000",
-        "name": "Test Course"
+        "name": "Test Course",
+        "year": 2015,
+        "term": "Winter",
+        "fullname": "Test Course Winter 2015"
     };
     beforeEach(module('ubc.ctlt.acj.course'));
     beforeEach(inject(function ($injector) {
@@ -95,7 +98,11 @@ describe('course-module', function () {
 
                 it('should be able to save new course', function () {
                     var course = {
-                        "name": "Test111", "descriptionCheck": true, "description": "<p>Description</p>\n"
+                        "name": "Test111",
+                        "year": 2015,
+                        "term": "Winter",
+                        "descriptionCheck": true,
+                        "description": "<p>Description</p>\n"
                     };
                     $rootScope.course = angular.copy(course);
                     $rootScope.course.id = undefined;
@@ -127,6 +134,8 @@ describe('course-module', function () {
                 it('should be able to save edited course', function () {
                     var editedCourse = angular.copy(editCourse);
                     editedCourse.name = 'new name';
+                    editedCourse.year = 2016;
+                    editedCourse.term = "Summer";
                     $rootScope.course = editedCourse;
                     $httpBackend.expectPOST('/api/courses/2', $rootScope.course).respond(editedCourse);
                     $httpBackend.expectGET('/api/session/permission').respond(mockSession['permissions']);

--- a/acj/static/modules/course/course-partial.html
+++ b/acj/static/modules/course/course-partial.html
@@ -12,6 +12,18 @@
                        type="text" class="form-control" required maxlength="255" placeholder="e.g. BIOL 112 - Biology of the Cell" auto-focus />
             </acj-field-with-feedback>
 
+            <acj-field-with-feedback form-control="courseForm.courseYear">
+                <label for="courseYear" class="required-star">Year</label>
+                <input id="courseYear" name="courseYear" ng-model="course.year"
+                       type="number" class="form-control" required min="1900" />
+            </acj-field-with-feedback>
+
+            <acj-field-with-feedback form-control="courseForm.courseTerm">
+                <label for="courseTerm" class="required-star">Term/Semester</label>
+                <input id="courseTerm" name="courseTerm" ng-model="course.term"
+                       type="text" class="form-control" required maxlength="255" />
+            </acj-field-with-feedback>
+
             <input id="descriptionCheck" type="checkbox" ng-model="course.descriptionCheck" ng-checked="course.descriptionCheck || course.description" ng-disabled="course.description">
             <label for="descriptionCheck">Add a course description<span ng-show="course.descriptionCheck || course.description">:</span></label>
             <br />

--- a/acj/static/test/factories/course_factory.js
+++ b/acj/static/test/factories/course_factory.js
@@ -3,7 +3,12 @@ var objectAssign = require('object-assign');
 var courseTemplate = {
     "id": null,
     "name": null,
+    "year": 2015,
+    "term": null,
+    "fullname": null,
     "description": null,
+    "start_time": null,
+    "end_time": null,
     "available": true,
     "modified": "Sun, 11 Jan 2015 08:44:46 -0000",
     "created": "Sun, 11 Jan 2015 08:44:46 -0000"

--- a/acj/static/test/factories/http_backend_mocks.js
+++ b/acj/static/test/factories/http_backend_mocks.js
@@ -208,7 +208,12 @@ module.exports.httpbackendMock = function(storageFixture) {
             var newCourse = {
                 "id": id,
                 "name": data.name,
+                "year": data.year,
+                "term": data.term,
+                "fullname": data.name + " " + data.term + " " + data.year,
                 "description": data.description,
+                "start_time": null,
+                "end_time": null,
                 "available": true,
                 "modified": "Sun, 11 Jan 2015 08:44:46 -0000",
                 "created": "Sun, 11 Jan 2015 08:44:46 -0000"

--- a/acj/static/test/features/create_course.feature
+++ b/acj/static/test/features/create_course.feature
@@ -20,6 +20,8 @@ Feature: Create Course
     And I fill in:
       | element     | content       |
       | course.name | Test Course 2 |
+      | course.year | 2015          |
+      | course.term | Winter        |
     And I fill in the course description with "This is the description for Test Course 2"
     And I submit form with "Save" button
     Then I should be on the "course" page

--- a/acj/static/test/features/edit_course.feature
+++ b/acj/static/test/features/edit_course.feature
@@ -19,6 +19,8 @@ Feature: Edit Course
     When I fill in:
       | element     | content   |
       | course.name | New Name  |
+      | course.year | 2020      |
+      | course.term | Winter    |
     And I fill in the course description with "This is the new description"
     And I submit form with "Save" button
     Then I should be on the "course" page

--- a/acj/static/test/fixtures/admin/has_assignments_fixture.js
+++ b/acj/static/test/fixtures/admin/has_assignments_fixture.js
@@ -34,6 +34,9 @@ storage.users.push(admin);
 
 var course = courseFactory.generateCourse(1, {
     name: "CHEM 111",
+    year: 2015,
+    term: "Winter",
+    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course);

--- a/acj/static/test/fixtures/admin/has_courses_fixture.js
+++ b/acj/static/test/fixtures/admin/has_courses_fixture.js
@@ -25,12 +25,18 @@ storage.users.push(admin);
 
 var course1 = courseFactory.generateCourse(1, {
     name: "CHEM 111",
+    year: 2015,
+    term: "Winter",
+    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course1);
 
 var course2 = courseFactory.generateCourse(2, {
     name: "PHYS 101",
+    year: 2015,
+    term: "Winter",
+    fullname: "PHYS 111 Winter 2015",
     description: "<p>PHYS 101  description<p>",
 });
 storage.courses.push(course2);

--- a/acj/static/test/fixtures/instructor/has_assignments_fixture.js
+++ b/acj/static/test/fixtures/instructor/has_assignments_fixture.js
@@ -44,6 +44,9 @@ storage.users.push(instructor);
 
 var course = courseFactory.generateCourse(1, {
     name: "CHEM 111",
+    year: 2015,
+    term: "Winter",
+    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course);

--- a/acj/static/test/fixtures/instructor/has_courses_fixture.js
+++ b/acj/static/test/fixtures/instructor/has_courses_fixture.js
@@ -36,12 +36,18 @@ storage.users.push(instructor);
 
 var course1 = courseFactory.generateCourse(1, {
     name: "CHEM 111",
+    year: 2015,
+    term: "Winter",
+    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course1);
 
 var course2 = courseFactory.generateCourse(2, {
     name: "PHYS 101",
+    year: 2015,
+    term: "Winter",
+    fullname: "PHYS 111 Winter 2015",
     description: "<p>PHYS 101  description<p>",
 });
 storage.courses.push(course2);

--- a/acj/static/test/fixtures/instructor/has_students_fixture.js
+++ b/acj/static/test/fixtures/instructor/has_students_fixture.js
@@ -58,6 +58,9 @@ storage.users.push(student2);
 
 var course = courseFactory.generateCourse(1, {
     name: "CHEM 111",
+    year: 2015,
+    term: "Winter",
+    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course);

--- a/acj/static/test/fixtures/student/has_assignments_fixture.js
+++ b/acj/static/test/fixtures/student/has_assignments_fixture.js
@@ -61,6 +61,9 @@ storage.users.push(student);
 
 var course = courseFactory.generateCourse(1, {
     name: "CHEM 111",
+    year: 2015,
+    term: "Winter",
+    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course);

--- a/acj/static/test/fixtures/student/has_courses_fixture.js
+++ b/acj/static/test/fixtures/student/has_courses_fixture.js
@@ -46,12 +46,18 @@ storage.users.push(student);
 
 var course1 = courseFactory.generateCourse(1, {
     name: "CHEM 111",
+    year: 2015,
+    term: "Winter",
+    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course1);
 
 var course2 = courseFactory.generateCourse(2, {
     name: "PHYS 101",
+    year: 2015,
+    term: "Winter",
+    fullname: "PHYS 111 Winter 2015",
     description: "<p>PHYS 101  description<p>",
 });
 storage.courses.push(course2);

--- a/alembic/versions/48e3b9d1750b_add_answer_id_and_criteriaquestion_id_.py
+++ b/alembic/versions/48e3b9d1750b_add_answer_id_and_criteriaquestion_id_.py
@@ -57,6 +57,5 @@ def downgrade():
             batch_op.drop_constraint('uq_Scores_answers_id_criteriaandquestions_id', type_='unique')
             batch_op.alter_column('answers_id', nullable=True, existing_type=sa.Integer)
     except ValueError:
-        logging.warn('Drop unique constraint is not support for SQLite, '
-                     'dropping uq_Scores_answers_id_criteriaandquestions_id ignored!')
+        logging.warn('Drop unique constraint is not support for SQLite, dropping uq_Scores_answers_id_criteriaandquestions_id ignored!')
 

--- a/alembic/versions/fff3fc7f636a_add_year_and_term_columns_to_course_.py
+++ b/alembic/versions/fff3fc7f636a_add_year_and_term_columns_to_course_.py
@@ -1,0 +1,40 @@
+"""Add year and term columns to course table
+
+Revision ID: fff3fc7f636a
+Revises: 144167b8fb35
+Create Date: 2016-07-12 11:09:13.082366
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'fff3fc7f636a'
+down_revision = '144167b8fb35'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import UniqueConstraint, exc
+from sqlalchemy.dialects import mysql
+
+from acj.models import convention
+
+def upgrade():
+    op.add_column('course', sa.Column('year', sa.Integer(), nullable=False, default='2015', server_default='2015'))
+    op.add_column('course', sa.Column('term', sa.String(length=255), nullable=False, default='', server_default=''))
+
+    try:
+        with op.batch_alter_table('course', naming_convention=convention,
+                table_args=(UniqueConstraint('name'))) as batch_op:
+            batch_op.drop_constraint('uq_course_name', type_='unique')
+    except exc.InternalError:
+        with op.batch_alter_table('course', naming_convention=convention,
+                table_args=(UniqueConstraint('name'))) as batch_op:
+            batch_op.drop_constraint('name', type_='unique')
+    except ValueError:
+        logging.warn('Drop unique constraint is not support for SQLite, dropping uq_course_name ignored!')
+
+def downgrade():
+    with op.batch_alter_table('course', naming_convention=convention,
+            table_args=(UniqueConstraint('name'))) as batch_op:
+        batch_op.drop_column('term')
+        batch_op.drop_column('year')
+        batch_op.create_unique_constraint('uq_course_name', ['name'])

--- a/data/factories.py
+++ b/data/factories.py
@@ -30,6 +30,8 @@ class CourseFactory(SQLAlchemyModelFactory):
     FACTORY_SESSION = db.session
 
     name = factory.Sequence(lambda n: u'TestCourse%d' % n)
+    year = 2015
+    term = "Winter"
     description = factory.fuzzy.FuzzyText(length=36)
     #start_date = datetime.datetime.now() - datetime.timedelta(days=7)
     #end_date = datetime.datetime.now() + datetime.timedelta(days=7)


### PR DESCRIPTION
Also removes the unique constraint on course name
Added fullname field to API course resources which will be the new name representation of courses
Added available field to API course resources which will indicate if course is currently active or not (start_date <= now < end_date if dates set)
Course form UI changes (year and term/semester) should be reviewed

Related #170