### PR TITLE
Add duplicate course API endpoint

### DIFF
--- a/acj/api/__init__.py
+++ b/acj/api/__init__.py
@@ -111,11 +111,13 @@ def log_events(log):
     on_user_password_update.connect(log)
 
     # course events
-    from .course import on_course_modified, on_course_get, on_course_list_get, on_course_create
+    from .course import on_course_modified, on_course_get, on_course_list_get, on_course_create, \
+        on_course_duplicate
     on_course_modified.connect(log)
     on_course_get.connect(log)
     on_course_list_get.connect(log)
     on_course_create.connect(log)
+    on_course_duplicate.connect(log)
 
     # assignment events
     from .assignment import on_assignment_modified, on_assignment_get, on_assignment_list_get, on_assignment_create, \

--- a/acj/api/file.py
+++ b/acj/api/file.py
@@ -121,6 +121,24 @@ def add_new_file(alias, name, model_name, model_id):
 
     return uploaded_file.id
 
+def duplicate_file(file, new_model_name, new_model_id):
+    tmp_name = str(new_model_name) + '_' + str(new_model_id) + '.pdf'
+
+    shutil.copy(
+        os.path.join(current_app.config['ATTACHMENT_UPLOAD_FOLDER'], file.name),
+        os.path.join(current_app.config['ATTACHMENT_UPLOAD_FOLDER'], tmp_name)
+    )
+
+    duplicated_file = File(user_id=current_user.id, name=tmp_name, alias=file.alias)
+
+    db.session.add(duplicated_file)
+    db.session.commit()
+    current_app.logger.debug(
+        "copied file id:" + str(file.id) + " from " + os.path.join(current_app.config['ATTACHMENT_UPLOAD_FOLDER'], file.name) +
+        " to " + os.path.join(current_app.config['ATTACHMENT_UPLOAD_FOLDER'], tmp_name))
+
+    return uploaded_file.id
+
 
 # delete file
 def delete_file(file_id):

--- a/acj/static/modules/course/course-module.js
+++ b/acj/static/modules/course/course-module.js
@@ -33,6 +33,7 @@ module.factory('CourseResource',
             'get': {url: url, cache: true},
             'save': {method: 'POST', url: url, interceptor: Interceptors.cache},
             'delete': {method: 'DELETE', url: url, interceptor: Interceptors.cache},
+            'createDuplicate': {method: 'POST', url: '/api/courses/:id/duplicate'},
             'getCurrentUserStatus': {url: '/api/courses/:id/assignments/status'},
             'getInstructorsLabels': {url: '/api/courses/:id/users/instructors/labels'},
             'getStudents': {url: '/api/courses/:id/users/students'}


### PR DESCRIPTION
Endpoint still expects a year and term to help differentiate the original for the duplicate (might be good to also include course start/end times as well).
Work still needs to be done on reasonable time-frames for start/end answer and comparison periods at the assignment level

Related: #318 