### PR TITLE
Add LTI assignment params to front-end

### DIFF
--- a/acj/api/dataformat/__init__.py
+++ b/acj/api/dataformat/__init__.py
@@ -109,6 +109,8 @@ def get_assignment(restrict_user=True):
 
         'compared': fields.Boolean,
 
+        'lti_linkable': fields.Boolean,
+
         'answer_period': fields.Boolean,
         'compare_period': fields.Boolean,
         'after_comparing': fields.Boolean,

--- a/acj/api/ltilaunch.py
+++ b/acj/api/ltilaunch.py
@@ -208,7 +208,9 @@ api.add_resource(LTICourseLinkAPI, '/lti/course/<int:course_id>/link')
 
 
 class MyRequestValidator(RequestValidator):
-    enforce_ssl = False
+    @property
+    def enforce_ssl(self):
+        return current_app.config.get('LTI_ENFORCE_SSL', True)
 
     def validate_timestamp_and_nonce(self, timestamp, nonce, request, request_token=None, access_token=None):
         return True

--- a/acj/models/assignment.py
+++ b/acj/models/assignment.py
@@ -54,6 +54,7 @@ class Assignment(DefaultTableMixin, ActiveMixin, WriteTrackingMixin):
     user_displayname = association_proxy('user', 'displayname')
     user_fullname = association_proxy('user', 'fullname')
     user_system_role = association_proxy('user', 'system_role')
+    lti_linkable = association_proxy('course', 'lti_linked')
 
     @hybrid_property
     def criteria(self):

--- a/acj/static/index.html
+++ b/acj/static/index.html
@@ -35,17 +35,19 @@
         <script src='lib/angular-loading-bar/build/loading-bar.js'></script>
         <script src='lib/AngularJS-Toaster/toaster.js'></script>
         <script src='lib/moment/moment.js'></script>
-        <script src='lib/momentjs/moment.js'></script>
         <script src='lib/angular-moment/angular-moment.js'></script>
         <script src='lib/angular-file-upload/angular-file-upload.min.js'></script>
         <script src='lib/angular-mocks/angular-mocks.js'></script>
         <script src='lib/angular-bootstrap/ui-bootstrap-tpls.js'></script>
+        <script src='lib/momentjs/moment.js'></script>
         <script src='lib/humanize-duration/humanize-duration.js'></script>
         <script src='lib/angular-timer/dist/angular-timer.js'></script>
         <script src='lib/lodash/lodash.js'></script>
         <script src='lib/blob-polyfill/Blob.js'></script>
         <script src='lib/file-saver.js/FileSaver.js'></script>
         <script src='lib/angular-file-saver/dist/angular-file-saver.js'></script>
+        <script src='lib/clipboard/dist/clipboard.js'></script>
+        <script src='lib/ngclipboard/dist/ngclipboard.js'></script>
         <!-- endbower -->
         <!-- endbuild -->
 

--- a/acj/static/less/assignment.less
+++ b/acj/static/less/assignment.less
@@ -212,3 +212,10 @@
 
 }//closes assignment-date
 
+.lti-param-copy {
+    display: inline-block;
+    margin-top: -2em;
+    font-size: 0.9em;
+    color: #888;
+}
+

--- a/acj/static/modules/assignment/assignment-form-partial.html
+++ b/acj/static/modules/assignment/assignment-form-partial.html
@@ -2,6 +2,15 @@
 
     <fieldset>
         <legend>Assignment</legend>
+        <div class="lti-param-copy pull-right" ng-show="assignment.id && assignment.lti_linkable">
+            LTI Parameter: "assignment={{assignment.id}}"
+            <!-- TODO: when ui bootstrap is updated change trigger to 'outsideClick' -->
+            <a href="" tooltip="Copied" tooltip-placement="bottom" tooltip-trigger="click"
+                  ngclipboard data-clipboard-text="assignment={{assignment.id}}">
+                Copy?
+            </a>
+        </div>
+
         <acj-field-with-feedback form-control="assignmentForm.assignmentName">
             <label for="assignmentName" class="required-star">Short Name</label>
             <input class="form-control" id="assignmentName" type="text"

--- a/acj/static/modules/assignment/assignment-module.js
+++ b/acj/static/modules/assignment/assignment-module.js
@@ -12,6 +12,8 @@ var module = angular.module('ubc.ctlt.acj.assignment',
     [
         'angularFileUpload',
         'ngResource',
+        'ngclipboard',
+        'ui.bootstrap',
         'ubc.ctlt.acj.answer',
         'ubc.ctlt.acj.authentication',
         'ubc.ctlt.acj.authorization',
@@ -25,8 +27,7 @@ var module = angular.module('ubc.ctlt.acj.assignment',
         'ubc.ctlt.acj.group',
         'ubc.ctlt.acj.comparison',
         'ubc.ctlt.acj.toaster',
-        'ubc.ctlt.acj.session',
-        'ui.bootstrap'
+        'ubc.ctlt.acj.session'
     ]
 );
 

--- a/acj/static/modules/lti/lti-module.js
+++ b/acj/static/modules/lti/lti-module.js
@@ -52,13 +52,6 @@ module.factory('LTI',
             return this._lti_status != null && this._lti_status.user &&
                 this._lti_status.user.exists == false;
         },
-        ltiLogoutRedirect: function() {
-            this._check_cookies();
-            if (this._lti_status != null && this._lti_status.redirect != null) {
-                return this._lti_status.redirect;
-            };
-            return false;
-        },
         endActiveSession: function() {
             this._lti_status = null;
             $cookies.remove('current.lti.status');

--- a/acj/tests/test_acj.py
+++ b/acj/tests/test_acj.py
@@ -66,6 +66,7 @@ class ACJTestCase(TestCase):
     def create_app(self):
         app = create_app(settings_override=test_app_settings)
         app.test_client_class = RecordableClient
+        app.config['LTI_ENFORCE_SSL'] = False
         return app
 
     def setUp(self):

--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,8 @@
     "angular-bootstrap": "~0.13.3",
     "angular-timer": "1.3.3",
     "lodash": "~3.10.1",
-    "angular-file-saver": "0.1.4"
+    "angular-file-saver": "0.1.4",
+    "ngclipboard": "~1.1.1"
   },
   "resolutions": {
     "angular": "1.4.7"


### PR DESCRIPTION
Assignments belonging to curses linked to LTI now display the LTI parameter when editing the assignment
Also switched LTI request validator to enforce ssl by default (add "LTI_ENFORCE_SSL = False" to config.py to get around ssl in development)