### PR TITLE
Furthers the work of issue #170, displaying courses over time

### DIFF
--- a/acj/api/dataformat/__init__.py
+++ b/acj/api/dataformat/__init__.py
@@ -66,7 +66,6 @@ def get_course(include_details=True):
         'name': fields.String,
         'year': fields.Integer,
         'term': fields.String,
-        'fullname': fields.String,
         'description': fields.String,
         'start_date': fields.DateTime,
         'end_date': fields.DateTime,

--- a/acj/models/course.py
+++ b/acj/models/course.py
@@ -27,10 +27,6 @@ class Course(DefaultTableMixin, ActiveMixin, WriteTrackingMixin):
 
     # hyprid and other functions
     @hybrid_property
-    def fullname(self):
-        return '%s %s %s' % (self.name, self.term, self.year)
-
-    @hybrid_property
     def available(self):
         now = dateutil.parser.parse(datetime.datetime.utcnow().replace(tzinfo=pytz.utc).isoformat())
 

--- a/acj/static/modules/assignment/assignment-module_spec.js
+++ b/acj/static/modules/assignment/assignment-module_spec.js
@@ -43,6 +43,8 @@ describe('course-module', function () {
     };
     var mockCourse = {
         "available": true,
+        "start_date": null,
+        "end_date": null,
         "created": "Fri, 09 Jan 2015 17:23:59 -0000",
         "description": null,
         "id": 1,
@@ -50,7 +52,6 @@ describe('course-module', function () {
         "name": "Test Course",
         "year": 2015,
         "term": "Winter",
-        "fullname": "Test Course Winter 2015",
         "start_time": null,
         "end_time": null
     };

--- a/acj/static/modules/comparison/comparison-module_spec.js
+++ b/acj/static/modules/comparison/comparison-module_spec.js
@@ -43,6 +43,8 @@ describe('comparison-module', function () {
     };
     var mockCourse = {
         "available": true,
+        "start_date": null,
+        "end_date": null,
         "created": "Fri, 09 Jan 2015 17:23:59 -0000",
         "description": null,
         "id": 1,
@@ -50,7 +52,6 @@ describe('comparison-module', function () {
         "name": "Test Course",
         "year": 2015,
         "term": "Winter",
-        "fullname": "Test Course Winter 2015",
         "start_time": null,
         "end_time": null
     };

--- a/acj/static/modules/course/course-assignments-partial.html
+++ b/acj/static/modules/course/course-assignments-partial.html
@@ -2,7 +2,7 @@
 
     <div class="row">
         <header class="col-sm-6">
-            <h1><i class="fa fa-book"></i> {{course.name}}</h1>
+            <h1><i class="fa fa-book"></i> {{course.name}} ({{course.year}} {{course.term}})</h1>
             <div class="intro-text" mathjax hljs ng-bind-html="course.description">
             </div>
         </header>
@@ -24,13 +24,6 @@
                     Manage Users
                 </a>
             </span>
-            <!-- <span ng-if="canCreateAssignments">
-                <a ng-href="#/course/{{course.id}}/gradebook"
-                    class="btn btn-primary">
-                    <i class="glyphicon glyphicon-tasks"></i>
-                    See Activity
-                </a>
-            </span> -->
         </div>
     </div>
 
@@ -44,8 +37,6 @@
             <form class="form-inline searchCourse" role="search" ng-show="assignments.length">
                 <div class="form-group filter">
                     <label>Show: &nbsp;</label>
-                    <!--<input class="form-control" type="text" ng-model="assignmentFilter.name"
-                        placeholder="Search assignment names">-->
                     <select ng-model="filter" ng-options="f for f in filters"></select>
                 </div>
             </form>
@@ -59,7 +50,7 @@
         <p ng-if="canCreateAssignments">Would you like to <a ng-href="#/course/{{course.id}}/assignment/create">add an assignment</a>?</p>
     </div>
 
-    <!-- assignments List -->
+    <!-- Assignments List -->
     <div class="row each-assignment" ng-class="{'first-child': $first}"
         ng-repeat="(key, assignment) in assignments | filter:assignmentFilter(filter) as results">
 
@@ -69,7 +60,7 @@
             <!-- Assignment Info -->
             <div class="media-body">
 
-                <!-- name -->
+                <!-- Name -->
                 <a ng-href="#/course/{{course.id}}/assignment/{{assignment.id}}">
                     <h3 class="media-heading">
                         <i class="fa fa-comments"></i>{{assignment.name}} &raquo;
@@ -98,12 +89,6 @@
                         Posted by
                         <a ng-href="#/user/{{assignment.user_id}}">
                             {{assignment.user.displayname}}
-                            <!-- <span ng-if="canManageAssignment && assignment.user.fullname">
-                                ({{assignment.user.fullname}})
-                            </span>
-                            <span ng-if="canManageAssignment && !assignment.user.fullname">
-                                ({{assignment.user.username}})
-                            </span> -->
                         </a>
                     </li>
                     <!-- Total Answers -->
@@ -132,7 +117,6 @@
                     <!-- Pending Assignment Feedback (for students) -->
                     <li ng-if="!canManageAssignment && ((assignment.compare_period && assignment.steps_left > 0) || (assignment.answer_period && !assignment.status.answers.answered))" class="label label-warning">
                         <span ng-if="assignment.answer_period && !assignment.status.answers.answered">1 answer<span ng-if="(assignment.compare_period && assignment.steps_left) > 0">, </span></span>
-
                         <span ng-if="assignment.compare_period && assignment.steps_left > 0">{{assignment.steps_left}} comparison<span ng-if="(assignment.steps_left) != 1">s</span></span>
                         needed from you
                     </li>

--- a/acj/static/modules/course/course-module_spec.js
+++ b/acj/static/modules/course/course-module_spec.js
@@ -43,14 +43,15 @@ describe('course-module', function () {
     };
     var mockCourse = {
         "available": true,
+        "start_date": null,
+        "end_date": null,
         "created": "Fri, 09 Jan 2015 17:23:59 -0000",
         "description": null,
         "id": 1,
         "modified": "Fri, 09 Jan 2015 17:23:59 -0000",
         "name": "Test Course",
         "year": 2015,
-        "term": "Winter",
-        "fullname": "Test Course Winter 2015"
+        "term": "Winter"
     };
     beforeEach(module('ubc.ctlt.acj.course'));
     beforeEach(inject(function ($injector) {
@@ -88,6 +89,21 @@ describe('course-module', function () {
         describe('view:', function () {
             var controller;
             describe('new', function () {
+                var toaster;
+                var course = {
+                    "name": "Test111",
+                    "year": 2015,
+                    "term": "Winter",
+                    "start_date": null,
+                    "end_date": null,
+                    "descriptionCheck": true,
+                    "description": "<p>Description</p>\n"
+                };
+                beforeEach(inject(function (_Toaster_) {
+                    toaster = _Toaster_;
+                    spyOn(toaster, 'error');
+                }));
+
                 beforeEach(function () {
                     controller = createController({current: {method: 'new'}});
                 });
@@ -96,14 +112,23 @@ describe('course-module', function () {
                     //double check nothing to initialize
                 });
 
+                it('should error when start date is not before end date', function () {
+                    $rootScope.course = angular.copy(course);
+                    $rootScope.course.id = undefined;
+                    $rootScope.date.course_start.date = new Date();
+                    $rootScope.date.course_start.time = new Date();
+                    $rootScope.date.course_end.date = new Date();
+                    $rootScope.date.course_end.time = new Date();
+                    $rootScope.date.course_end.date.setDate($rootScope.date.course_end.date.getDate()-1);
+                    var currentPath = $location.path();
+
+                    $rootScope.save();
+                    expect($rootScope.submitted).toBe(false);
+                    expect(toaster.error).toHaveBeenCalledWith('Course Period Conflict', 'Course end date/time must be after course start date/time.');
+                    expect($location.path()).toEqual(currentPath);
+                });
+
                 it('should be able to save new course', function () {
-                    var course = {
-                        "name": "Test111",
-                        "year": 2015,
-                        "term": "Winter",
-                        "descriptionCheck": true,
-                        "description": "<p>Description</p>\n"
-                    };
                     $rootScope.course = angular.copy(course);
                     $rootScope.course.id = undefined;
                     $httpBackend.expectPOST('/api/courses', $rootScope.course).respond(angular.merge({}, course, {id: 2}));
@@ -118,6 +143,11 @@ describe('course-module', function () {
 
             describe('edit', function () {
                 var editCourse;
+                var toaster;
+                beforeEach(inject(function (_Toaster_) {
+                    toaster = _Toaster_;
+                    spyOn(toaster, 'error');
+                }));
 
                 beforeEach(function () {
                     editCourse = angular.copy(mockCourse);
@@ -129,6 +159,22 @@ describe('course-module', function () {
 
                 it('should be correctly initialized', function () {
                     expect($rootScope.course).toEqualData(_.merge(editCourse));
+                });
+
+                it('should error when start date is not before end date', function () {
+                    var editedCourse = angular.copy(editCourse);
+                    $rootScope.course = editedCourse;
+                    $rootScope.date.course_start.date = new Date();
+                    $rootScope.date.course_start.time = new Date();
+                    $rootScope.date.course_end.date = new Date();
+                    $rootScope.date.course_end.time = new Date();
+                    $rootScope.date.course_end.date.setDate($rootScope.date.course_end.date.getDate()-1);
+                    var currentPath = $location.path();
+
+                    $rootScope.save();
+                    expect($rootScope.submitted).toBe(false);
+                    expect(toaster.error).toHaveBeenCalledWith('Course Period Conflict', 'Course end date/time must be after course start date/time.');
+                    expect($location.path()).toEqual(currentPath);
                 });
 
                 it('should be able to save edited course', function () {

--- a/acj/static/modules/course/course-partial.html
+++ b/acj/static/modules/course/course-partial.html
@@ -11,21 +11,24 @@
                 <input id="courseName" name="courseName" ng-model="course.name"
                        type="text" class="form-control" required maxlength="255" placeholder="e.g. BIOL 112 - Biology of the Cell" auto-focus />
             </acj-field-with-feedback>
-
-            <acj-field-with-feedback form-control="courseForm.courseYear">
-                <label for="courseYear" class="required-star">Year</label>
-                <input id="courseYear" name="courseYear" ng-model="course.year"
-                       type="number" class="form-control" required min="1900" />
-            </acj-field-with-feedback>
-
-            <acj-field-with-feedback form-control="courseForm.courseTerm">
-                <label for="courseTerm" class="required-star">Term/Semester</label>
-                <input id="courseTerm" name="courseTerm" ng-model="course.term"
-                       type="text" class="form-control" required maxlength="255" />
-            </acj-field-with-feedback>
-
+	    <div class="row">
+		<div class="col-md-6 form-group">
+			<acj-field-with-feedback form-control="courseForm.courseYear">
+			    <label for="courseYear" class="required-star">Year</label>
+			    <input id="courseYear" name="courseYear" ng-model="course.year"
+				   type="number" class="form-control" required min="1900" />
+			</acj-field-with-feedback>
+		</div>
+		<div class="col-md-6 form-group">
+			<acj-field-with-feedback form-control="courseForm.courseTerm">
+			    <label for="courseTerm" class="required-star">Term/Semester</label>
+			    <input id="courseTerm" name="courseTerm" ng-model="course.term"
+				   type="text" class="form-control" required maxlength="255" />
+			</acj-field-with-feedback>
+		</div>
+	    </div>
             <input id="descriptionCheck" type="checkbox" ng-model="course.descriptionCheck" ng-checked="course.descriptionCheck || course.description" ng-disabled="course.description">
-            <label for="descriptionCheck">Add a course description<span ng-show="course.descriptionCheck || course.description">:</span></label>
+            <label for="descriptionCheck">Add a course description (optional)<span ng-show="course.descriptionCheck || course.description">:</span></label>
             <br />
 
             <div ng-if="course.descriptionCheck || course.description">
@@ -34,6 +37,43 @@
                 </div>
             </div>
         </fieldset>
+
+	<fieldset>
+            <legend>Schedule</legend>
+	    <div class="instructional-text">
+		<p><strong>Optionally set the course dates</strong> during which enrolled students can see and access the course content when they log in. Setting no dates means the course is always accessible to students. (You will be able to set different dates for individual assignments when you create them.) </p>
+	    </div>
+	    <div class="row">
+            <div class="col-md-6 form-group">
+                <label>Course Begins</label><br />
+                <div class="assignment-date">
+                    <span class="input-group">
+                        <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="date.course_start.date" is-open="date.course_start.opened" />
+                        <span class="input-group-btn">
+                            <button type="button" class="btn btn-default" ng-click="date.course_start.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                        </span>
+                    </span>
+                </div>
+                <div class="assignment-date">
+                    <timepicker ng-model="date.course_start.time" minute-step="1" mousewheel="false"></timepicker>
+                </div>
+            </div>
+            <div class="col-md-6 form-group">
+                <label>Course Ends</label><br />
+                <div class="assignment-date">
+                    <span class="input-group">
+                        <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="date.course_end.date" is-open="date.course_end.opened" />
+                        <span class="input-group-btn">
+                            <button type="button" class="btn btn-default" ng-click="date.course_end.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                        </span>
+                    </span>
+                </div>
+                <div class="assignment-date">
+                    <timepicker ng-model="date.course_end.time" minute-step="1" mousewheel="false"></timepicker>
+                </div>
+            </div>
+        </div>
+	</fieldset>
 
         <input type="submit" class="btn btn-success btn-lg center-block" value="Save"
                ng-disabled="courseForm.$invalid || submitted" />

--- a/acj/static/modules/home/home-module.js
+++ b/acj/static/modules/home/home-module.js
@@ -38,6 +38,7 @@ module.controller(
                 {id: user.id}).$promise.then(
                 function(ret) {
                     $scope.courses = ret.objects;
+                    angular.forEach($scope.courses, function(event){ event.start_date = new Date(event.start_date); });
                 },
                 function (ret) {
                     Toaster.reqerror("Unable to retrieve your courses.", ret);

--- a/acj/static/modules/home/home-partial.html
+++ b/acj/static/modules/home/home-partial.html
@@ -22,11 +22,11 @@
 
     <!-- Course listing -->
     <div class="course-list" ng-if="courses.length">
-        <a ng-repeat="course in courses | filter:courseFilter"
+        <a ng-repeat="course in courses | filter:courseFilter | orderBy:'start_date':true"
             ng-href="#/course/{{course.id}}" class="each-course">
             <h3 class="clearfix">
                 <i class="fa fa-book"></i>
-                {{course.name}}
+                {{course.name}} ({{course.year}} {{course.term}})
                 <i class="fa fa-arrow-right fa-2x pull-right hidden-xs"></i>
             </h3>
         </a>

--- a/acj/static/test/factories/course_factory.js
+++ b/acj/static/test/factories/course_factory.js
@@ -5,11 +5,12 @@ var courseTemplate = {
     "name": null,
     "year": 2015,
     "term": null,
-    "fullname": null,
     "description": null,
     "start_time": null,
     "end_time": null,
     "available": true,
+    "start_date": null,
+    "end_date": null,
     "modified": "Sun, 11 Jan 2015 08:44:46 -0000",
     "created": "Sun, 11 Jan 2015 08:44:46 -0000"
 }

--- a/acj/static/test/factories/http_backend_mocks.js
+++ b/acj/static/test/factories/http_backend_mocks.js
@@ -210,11 +210,10 @@ module.exports.httpbackendMock = function(storageFixture) {
                 "name": data.name,
                 "year": data.year,
                 "term": data.term,
-                "fullname": data.name + " " + data.term + " " + data.year,
                 "description": data.description,
-                "start_time": data.start_time,
-                "end_time": data.end_time,
                 "available": true,
+                "start_date": data.start_date,
+                "end_date": data.end_date,
                 "modified": "Sun, 11 Jan 2015 08:44:46 -0000",
                 "created": "Sun, 11 Jan 2015 08:44:46 -0000"
             }

--- a/acj/static/test/features/create_course.feature
+++ b/acj/static/test/features/create_course.feature
@@ -16,7 +16,7 @@ Feature: Create Course
   Scenario: Creating a course as instructor
     Given I'm an Instructor
     And I'm on "create course" page
-    When I toggle the "Add a course description:" checkbox
+    When I toggle the "Add a course description (optional)" checkbox
     And I fill in:
       | element     | content       |
       | course.name | Test Course 2 |
@@ -25,5 +25,5 @@ Feature: Create Course
     And I fill in the course description with "This is the description for Test Course 2"
     And I submit form with "Save" button
     Then I should be on the "course" page
-    And I should see "Test Course 2" in "h1" on the page
+    And I should see "Test Course 2 (2015 Winter)" in "h1" on the page
     And I should see "This is the description for Test Course 2" in "div.intro-text" on the page

--- a/acj/static/test/features/edit_course.feature
+++ b/acj/static/test/features/edit_course.feature
@@ -24,5 +24,5 @@ Feature: Edit Course
     And I fill in the course description with "This is the new description"
     And I submit form with "Save" button
     Then I should be on the "course" page
-    And I should see "New Name" in "h1" on the page
+    And I should see "New Name (2020 Winter)" in "h1" on the page
     And I should see "This is the new description" in "div.intro-text" on the page

--- a/acj/static/test/features/step_definitions/view_home.js
+++ b/acj/static/test/features/step_definitions/view_home.js
@@ -9,7 +9,7 @@ var expect = chai.expect;
 var viewHomeStepDefinitionsWrapper = function () {
     this.Then(/^I should see my courses with names:$/, function (data, done) {
         var list = data.hashes().map(function(item) {
-            return item.name;
+            return item.name + " ("+item.year+" "+item.term+")";
         });
 
         expect(element.all(by.css(".course-list a h3")).getText()).to.eventually.eql(list).and.notify(done);

--- a/acj/static/test/features/view_home.feature
+++ b/acj/static/test/features/view_home.feature
@@ -5,17 +5,17 @@ Feature: View Home
     Given I'm a System Administrator with courses
     And I'm on "home" page
     Then I should see my courses with names:
-      | name          |
-      | CHEM 111      |
-      | PHYS 101      |
+      | name     | year | term    |
+      | PHYS 101 | 2015 | Winter  |
+      | CHEM 111 | 2015 | Winter  |
 
   Scenario: Loading home page as instructor
     Given I'm an Instructor with courses
     And I'm on "home" page
     Then I should see my courses with names:
-      | name          |
-      | CHEM 111      |
-      | PHYS 101      |
+      | name     | year | term    |
+      | PHYS 101 | 2015 | Winter  |
+      | CHEM 111 | 2015 | Winter  |
 
   Scenario: Filtering home page courses as instructor
     Given I'm an Instructor with courses
@@ -23,13 +23,13 @@ Feature: View Home
     When I filter home page courses by "CHEM"
     Then I should see "1" courses
     And I should see my courses with names:
-      | name          |
-      | CHEM 111      |
+      | name     | year | term    |
+      | CHEM 111 | 2015 | Winter  |
 
   Scenario: Loading home page as student
     Given I'm a Student with courses
     And I'm on "home" page
     Then I should see my courses with names:
-      | name          |
-      | CHEM 111      |
-      | PHYS 101      |
+      | name     | year | term    |
+      | PHYS 101 | 2015 | Winter  |
+      | CHEM 111 | 2015 | Winter  |

--- a/acj/static/test/fixtures/admin/has_assignments_fixture.js
+++ b/acj/static/test/fixtures/admin/has_assignments_fixture.js
@@ -36,7 +36,6 @@ var course = courseFactory.generateCourse(1, {
     name: "CHEM 111",
     year: 2015,
     term: "Winter",
-    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course);

--- a/acj/static/test/fixtures/admin/has_courses_fixture.js
+++ b/acj/static/test/fixtures/admin/has_courses_fixture.js
@@ -27,7 +27,6 @@ var course1 = courseFactory.generateCourse(1, {
     name: "CHEM 111",
     year: 2015,
     term: "Winter",
-    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course1);
@@ -36,7 +35,6 @@ var course2 = courseFactory.generateCourse(2, {
     name: "PHYS 101",
     year: 2015,
     term: "Winter",
-    fullname: "PHYS 111 Winter 2015",
     description: "<p>PHYS 101  description<p>",
 });
 storage.courses.push(course2);

--- a/acj/static/test/fixtures/instructor/has_assignments_fixture.js
+++ b/acj/static/test/fixtures/instructor/has_assignments_fixture.js
@@ -46,7 +46,6 @@ var course = courseFactory.generateCourse(1, {
     name: "CHEM 111",
     year: 2015,
     term: "Winter",
-    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course);

--- a/acj/static/test/fixtures/instructor/has_courses_fixture.js
+++ b/acj/static/test/fixtures/instructor/has_courses_fixture.js
@@ -38,7 +38,6 @@ var course1 = courseFactory.generateCourse(1, {
     name: "CHEM 111",
     year: 2015,
     term: "Winter",
-    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course1);
@@ -47,7 +46,6 @@ var course2 = courseFactory.generateCourse(2, {
     name: "PHYS 101",
     year: 2015,
     term: "Winter",
-    fullname: "PHYS 111 Winter 2015",
     description: "<p>PHYS 101  description<p>",
 });
 storage.courses.push(course2);

--- a/acj/static/test/fixtures/instructor/has_students_fixture.js
+++ b/acj/static/test/fixtures/instructor/has_students_fixture.js
@@ -60,7 +60,6 @@ var course = courseFactory.generateCourse(1, {
     name: "CHEM 111",
     year: 2015,
     term: "Winter",
-    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course);

--- a/acj/static/test/fixtures/student/has_assignments_fixture.js
+++ b/acj/static/test/fixtures/student/has_assignments_fixture.js
@@ -63,7 +63,6 @@ var course = courseFactory.generateCourse(1, {
     name: "CHEM 111",
     year: 2015,
     term: "Winter",
-    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course);

--- a/acj/static/test/fixtures/student/has_courses_fixture.js
+++ b/acj/static/test/fixtures/student/has_courses_fixture.js
@@ -48,7 +48,6 @@ var course1 = courseFactory.generateCourse(1, {
     name: "CHEM 111",
     year: 2015,
     term: "Winter",
-    fullname: "CHEM 111 Winter 2015",
     description: "<p>CHEM 111 description<p>",
 });
 storage.courses.push(course1);
@@ -57,7 +56,6 @@ var course2 = courseFactory.generateCourse(2, {
     name: "PHYS 101",
     year: 2015,
     term: "Winter",
-    fullname: "PHYS 111 Winter 2015",
     description: "<p>PHYS 101  description<p>",
 });
 storage.courses.push(course2);


### PR DESCRIPTION
Includes:
- Adding fields, text to the course form for selecting start/end dates (optional)
- Enabling saving/editing of start/end dates
- Updating fields on the courses form for term/semester and year (required)
- Updating name to what instructor enters plus year and term/semester
- Sorting courses for instructors on home page by start date