### PR TITLE
Completes issue #258, allowing drafts to be saved for answers and comparisons

### DIFF
--- a/acj/static/modules/answer/answer-form-partial.html
+++ b/acj/static/modules/answer/answer-form-partial.html
@@ -1,4 +1,4 @@
-<p class="intro-text">Please note <strong>answers are not automatically saved</strong> as you type.</p>
+<p class="intro-text">Please note <strong>answers are not automatically saved</strong> as you type. However, you may manually save a draft of your answer below.</p>
 
 <form class="form" name="answerForm" ng-submit="answerSubmit()" novalidate confirm-form-exit form-type="answer">
     <fieldset>
@@ -16,7 +16,7 @@
                 <span title="Official time remaining until deadline" class="bg-danger alert text-danger">{{minutes}} minutes {{seconds}} seconds left</span>
             </timer>
             <br /><br />
-            <span class="h4">(Answer must be saved by deadline to be accepted)</span>
+            <span class="h4">(Answer must be submitted by deadline to be accepted)</span>
         </div>
 
         <div class="form-group" ng-if="canManageAssignment && showUserList">
@@ -64,17 +64,14 @@
             </textarea>
         </div>
     </fieldset>
-    <div class="row" ng-show="answer.draft">
-        <div class="col-md-3 col-md-offset-3 col-xs-6">
-            <input type="submit" class="btn btn-success btn-lg center-block" value="Save Draft"
-                ng-click="answer.draft = true"
-                ng-disabled="submitted || (uploader.queue.length && !uploader.queue[0].isSuccess)" />
-        </div>
-        <div class="col-md-3 col-xs-6">
-            <input type="submit" class="btn btn-success btn-lg center-block" value="Submit Answer"
-                ng-click="answer.draft = false"
-                ng-disabled="answerForm.$invalid || submitted || (uploader.queue.length && !uploader.queue[0].isSuccess)" />
-        </div>
+    <div class="text-center" ng-show="answer.draft">
+        <input type="submit" class="btn btn-default btn-lg" value="Save Draft"
+		    ng-click="answer.draft = true"
+		    ng-disabled="answerForm.$invalid || submitted || (uploader.queue.length && !uploader.queue[0].isSuccess)" />
+		&nbsp; &nbsp;
+		<input type="submit" class="btn btn-success btn-lg" value="Submit"
+            ng-click="answer.draft = false"
+            ng-disabled="answerForm.$invalid || submitted || (uploader.queue.length && !uploader.queue[0].isSuccess)" />
     </div>
     <div ng-show="!answer.draft">
         <input type="submit" class="btn btn-success btn-lg center-block" value="Save"

--- a/acj/static/modules/answer/answer-module.js
+++ b/acj/static/modules/answer/answer-module.js
@@ -207,11 +207,13 @@ module.controller(
                         }
 
                         Toaster.success("Saved Draft Successfully!", "Remember to submit your answer before the deadline.");
+                        $scope.preventExit = false; //user has saved answer, does not need warning when leaving page
+                        $location.path('/course/' + $scope.courseId + '/assignment/' + assignmentId + '/answer/' + $scope.answer.id + '/edit');
                     } else {
                         $scope.preventExit = false; //user has saved answer, does not need warning when leaving page
                         // if was a draft, show new success message
                         if (wasDraft) {
-                            Toaster.success("New answer posted!");
+                            Toaster.success("New Answer Posted!");
                         } else {
                             Toaster.success("Answer Updated!");
                         }

--- a/acj/static/modules/assignment/assignment-view-partial.html
+++ b/acj/static/modules/assignment/assignment-view-partial.html
@@ -66,7 +66,7 @@
         <!-- BUTTON when user has an answer draft AND (user is admin OR (user has not answered AND the answer period is active) -->
         <a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/answer/{{assignment.status.answers.draft_ids[0]}}/edit" class="btn btn-success" title="Answer Assignment"
            ng-show="assignment.status.answers.has_draft && (canManageAssignment || (!assignment.status.answers.answered && assignment.answer_period))">
-            Finish Answering
+            Finish Answer
         </a>
 
         <!-- BUTTON when user is not an admin AND the comparison period is active AND the user has not finished pair comparisons AND either (the answer period is active AND the assignment has been answered) OR (the answer period is not active)
@@ -166,7 +166,7 @@
                 <!-- Students should see before answering during the answer period -->
                 <p class="intro-text"
                    ng-if="!canManageAssignment && !assignment.status.answers.answered && assignment.answer_period">
-                    <a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/answer/create" title="Answer the assignment">Answer</a> and compare answer pairs for the assignment first, then read all answers written by your classmates and instructors here.
+                    <span ng-show="!assignment.status.answers.has_draft"><a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/answer/create" title="Answer the assignment">Answer</a></span><span ng-show="assignment.status.answers.has_draft"><a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/answer/{{assignment.status.answers.draft_ids[0]}}/edit" title="Finish answering the assignment">Finish answering</a></span> and compare answer pairs for the assignment first, then read all answers written by your classmates and instructors here.
                 </p>
 
                 <!-- Students should see before evaluating before the comparison period -->

--- a/acj/static/modules/common/form-directives.js
+++ b/acj/static/modules/common/form-directives.js
@@ -43,22 +43,22 @@ module.directive('confirmFormExit', function(){
             window.onbeforeunload = function() {
                 //when confirmation is for answer AND an answer has been written or PDF file uploaded AND the user has not pressed submit
                 if (attrs.formType == 'answer' && (scope.answer.content || scope.uploader.queue.length) && scope.preventExit) {
-                    return "Do you want to refresh this page without saving? Any answering you've done will be lost.";
+                    return "Are you sure you want to refresh this page? Any unsaved changed you've made will be lost.";
                 }
                 //when confirmation is for comparison AND the user has not pressed submit
                 if (attrs.formType == 'compare' && scope.preventExit) {
-                    return "Do you want to refresh this page without saving? Any work you've done for this answer pair will be lost.";
+                    return "Are you sure you want to refresh this page? Any unsaved work you've done for this round will be lost.";
                 }
             }
             //change URL
             scope.$on('$locationChangeStart', function(event, next, current) {
                 if (attrs.formType == 'answer' && (scope.answer.content || scope.uploader.queue.length) && scope.preventExit) {
-                    if (!confirm("Do you want to leave this page without saving? Any answering you've done will be lost.")) {
+                    if (!confirm("Are you sure you want to leave this page? Any unsaved changes you've made will be lost.")) {
                         event.preventDefault();
                     }
                 }
                 if (attrs.formType == 'compare' && scope.preventExit) {
-                    if (!confirm("Do you want to leave this page without saving? Any work you've done for this answer pair will be lost.")) {
+                    if (!confirm("Are you sure you want to leave this page? Any unsaved work you've done for this round will be lost.")) {
                         event.preventDefault();
                     }
                 }

--- a/acj/static/modules/comparison/comparison-core.html
+++ b/acj/static/modules/comparison/comparison-core.html
@@ -2,7 +2,7 @@
 
     <h1>Compare Answers</h1>
 
-    <p class="intro-text">For each round, you'll give helpful feedback on the answers in the pair, choose which better matches the criteria below, and submit the comparison. Please note <strong>answers are not automatically saved</strong> as you type.</p>
+    <p class="intro-text">For each round, you'll give helpful feedback on the answers in the pair, choose which better matches the criteria below, and submit the comparison. Please note <strong>answers are not automatically saved</strong> as you type. However, you may manually save a draft of the round below.</p>
 
     <p class="assignment-toggle"><a href="" ng-click="showAssignment = !showAssignment">
         <i class="fa fa-chevron-down" ng-show="showAssignment "></i>
@@ -27,7 +27,7 @@
                 <span title="Official time remaining until deadline" class="bg-danger alert text-danger">{{minutes}} minutes {{seconds}} seconds left</span>
             </timer>
             <br /><br />
-            <span class="h4">(Comparison must be saved by deadline to be accepted)</span>
+            <span class="h4">(Comparison must be submitted by deadline to be accepted)</span>
         </div>
 
         <h2 class="col-md-6">Answer Pair</h2>
@@ -180,26 +180,21 @@
 
             </div>
 
-            <div class="form-group sub-step">
-                <div class="row">
-                    <div class="col-md-3 col-md-offset-3 col-xs-6">
-                        <input ng-disabled="submitted" type="submit"
-                            ng-click="$parent.isDraft = true"
-                            value="Save Draft" class="btn btn-success btn-lg center-block" />
-                    </div>
-                    <div class="col-md-3 col-xs-6">
-                        <!-- button to submit and refresh page IF evaluations remain for user -->
-                        <input ng-disabled="comparisonForm.$invalid || submitted" type="submit"
-                            ng-click="$parent.isDraft = false"
-                            value="Submit" class="btn btn-success btn-lg center-block" />
-                    </div>
-                </div>
-                <p ng-if="submitted" class="text-center" >
+            <div class="form-group sub-step text-center">
+                <input ng-disabled="submitted" type="submit"
+                    ng-click="$parent.isDraft = true"
+                    value="Save Draft" class="btn btn-default btn-lg" />
+                &nbsp; &nbsp;
+                <!-- button to submit and refresh page IF evaluations remain for user -->
+                <input ng-disabled="comparisonForm.$invalid || submitted" type="submit"
+                    ng-click="$parent.isDraft = false"
+                    value="Submit" class="btn btn-success btn-lg" />
+                <p ng-if="submitted">
                     <i class="fa fa-spin fa-spinner"></i>
                     &nbsp; Saving comparison...
                 </p>
             </div>
-
+            
         </div>
 
     </form>

--- a/acj/static/modules/comparison/comparison-module.js
+++ b/acj/static/modules/comparison/comparison-module.js
@@ -64,7 +64,7 @@ module.controller(
                 $scope.total = $scope.assignment.total_steps_required;
                 // if there is a comparison end date, check if timer is needed
                 var due_date = new Date($scope.assignment.compare_end);
-                if (due_date) {
+                if (due_date && $scope.assignment.compare_end != null) {
                     TimerResource.get(
                         function (ret) {
                             var current_time = ret.date;


### PR DESCRIPTION
Includes:
- Updating instructional and warning text
- Differentiating save/submit buttons more
- Redirecting user after save answer draft to edit answer screen
- Updating draft button text, URLs
- Changing leave page warning text
- Fixing issue with timer displaying when compare date is null