### PR TITLE
Fix #343

### DIFF
--- a/acj/static/modules/answer/answer-form-partial.html
+++ b/acj/static/modules/answer/answer-form-partial.html
@@ -1,6 +1,6 @@
 <p class="intro-text">Please note <strong>answers are not automatically saved</strong> as you type. However, you may manually save a draft of your answer below.</p>
 
-<form class="form" name="answerForm" ng-submit="answerSubmit()" novalidate confirm-form-exit form-type="answer">
+<form class="form" name="answerForm" ng-submit="answerSubmit(answerForm)" novalidate confirm-form-exit form-type="answer">
     <fieldset>
         <h2><i class="fa fa-comments"></i> {{assignment.name}}</h2>
         <div class="assignment-desc" mathjax hljs ng-bind-html="assignment.description"></div>
@@ -29,7 +29,7 @@
         <div>
             <label for="importFile">Attach PDF (maximum size 25MB)</label>
             <p ng-hide="(uploader.queue.length) || (answer.file && answer.uploadedFile)"><span class="required-star"></span><em>Tip: Try downloading <a href="https://get.adobe.com/reader/">Acrobat Reader</a> or using <a href="https://www.mozilla.org/en-US/firefox/new/">Firefox</a> or <a href="http://www.google.com/chrome/">Chrome</a> if you have problems uploading.</em></p>
-            <input type="file" nv-file-select uploader="uploader" id="importFile" ng-hide="(uploader.queue.length) || (answer.file && answer.uploadedFile)" multiple/>
+            <input type="file" nv-file-select uploader="uploader" ng-click="answerForm.$setDirty()" id="importFile" ng-hide="(uploader.queue.length) || (answer.file && answer.uploadedFile)" multiple/>
             <p class="instructional-text" ng-show="uploader.queue.length"><strong>Save this answer</strong> to submit the file below. You may also remove the file and upload another instead.</p>
             <div class="row" ng-repeat="item in uploader.queue">
                 <div class="col-md-7"><i class="fa fa-paperclip"></i> File: <strong>{{item.file.name}}</strong></div>

--- a/acj/static/modules/answer/answer-module.js
+++ b/acj/static/modules/answer/answer-module.js
@@ -188,7 +188,7 @@ module.controller(
             }
         );
 
-        $scope.answerSubmit = function () {
+        $scope.answerSubmit = function (answerForm) {
             $scope.submitted = true;
             $scope.answer.file_name = attachService.getName();
             $scope.answer.file_alias = attachService.getAlias();
@@ -204,6 +204,9 @@ module.controller(
                             $scope.answer.uploadedFile = ret.file;
                             $scope.uploader.clearQueue();
                             $scope.resetName();
+                        }
+                        if (answerForm) {
+                            answerForm.$setPristine();
                         }
 
                         Toaster.success("Saved Draft Successfully!", "Remember to submit your answer before the deadline.");

--- a/acj/static/modules/common/form-directives.js
+++ b/acj/static/modules/common/form-directives.js
@@ -37,34 +37,36 @@ module.directive('pwMatch', function(){
 
 /* prompt user when leaving page with unsaved work (applied only to forms for creating answer, creating comparison) */
 module.directive('confirmFormExit', function(){
-        return {
-        link: function(scope, elem, attrs) {
+    return {
+        require: 'form',
+        link: function(scope, elem, attrs, formController) {
             //refresh
             window.onbeforeunload = function() {
                 //when confirmation is for answer AND an answer has been written or PDF file uploaded AND the user has not pressed submit
-                if (attrs.formType == 'answer' && (scope.answer.content || scope.uploader.queue.length) && scope.preventExit) {
+                if (attrs.formType == 'answer' && (scope.answer.content || scope.uploader.queue.length) && scope.preventExit && formController.$dirty) {
                     return "Are you sure you want to refresh this page? Any unsaved changed you've made will be lost.";
                 }
                 //when confirmation is for comparison AND the user has not pressed submit
-                if (attrs.formType == 'compare' && scope.preventExit) {
+                if (attrs.formType == 'compare' && scope.preventExit && formController.$dirty) {
                     return "Are you sure you want to refresh this page? Any unsaved work you've done for this round will be lost.";
                 }
             }
             //change URL
             scope.$on('$locationChangeStart', function(event, next, current) {
-                if (attrs.formType == 'answer' && (scope.answer.content || scope.uploader.queue.length) && scope.preventExit) {
+                console.log(formController, formController.$dirty)
+                if (attrs.formType == 'answer' && (scope.answer.content || scope.uploader.queue.length) && scope.preventExit && formController.$dirty) {
                     if (!confirm("Are you sure you want to leave this page? Any unsaved changes you've made will be lost.")) {
                         event.preventDefault();
                     }
                 }
-                if (attrs.formType == 'compare' && scope.preventExit) {
+                if (attrs.formType == 'compare' && scope.preventExit && formController.$dirty) {
                     if (!confirm("Are you sure you want to leave this page? Any unsaved work you've done for this round will be lost.")) {
                         event.preventDefault();
                     }
                 }
             });
         }
-        };
+    };
 });
 
 /***** Providers *****/

--- a/acj/static/modules/comparison/comparison-core.html
+++ b/acj/static/modules/comparison/comparison-core.html
@@ -83,7 +83,7 @@
 
     </div>
 
-    <form name="comparisonForm" ng-submit="comparisonSubmit()" novalidate ng-hide="comparisonsError" confirm-form-exit form-type="compare">
+    <form name="comparisonForm" ng-submit="comparisonSubmit(comparisonForm)" novalidate ng-hide="comparisonsError" confirm-form-exit form-type="compare">
 
         <div>
 

--- a/acj/static/modules/comparison/comparison-module.js
+++ b/acj/static/modules/comparison/comparison-module.js
@@ -144,7 +144,7 @@ module.controller(
         //};
 
         // save comparison to server
-        $scope.comparisonSubmit = function() {
+        $scope.comparisonSubmit = function(comparisonForm) {
             $scope.submitted = true;
             // save comments for each individual answer
             angular.forEach([$scope.answer1, $scope.answer2], function(answer) {
@@ -207,6 +207,9 @@ module.controller(
                             }
                         );
                     } else {
+                        if (comparisonForm) {
+                            comparisonForm.$setPristine();
+                        }
                         Toaster.success("Saved Draft Successfully!", "Remember to submit your comparison before the deadline.");
                     }
                 },


### PR DESCRIPTION
warning messages will no longer be displayed when leaving the answer/comparison forms after saving a draft unless the user makes further changes