### PR TITLE
Add rank display limit to assignment

### DIFF
--- a/acj/api/assignment.py
+++ b/acj/api/assignment.py
@@ -34,6 +34,7 @@ new_assignment_parser.add_argument('students_can_reply', type=bool, default=Fals
 new_assignment_parser.add_argument('number_of_comparisons', type=int, required=True)
 new_assignment_parser.add_argument('enable_self_evaluation', type=int, default=None)
 new_assignment_parser.add_argument('pairing_algorithm', type=str, default=None)
+new_assignment_parser.add_argument('rank_display_limit', type=int, default=None)
 # has to add location parameter, otherwise MultiDict will screw up the list
 new_assignment_parser.add_argument('criteria', type=list, default=[], location='json')
 
@@ -117,6 +118,9 @@ class AssignmentIdAPI(Resource):
         pairing_algorithm = params.get("pairing_algorithm")
         check_valid_pairing_algorithm(pairing_algorithm)
         assignment.pairing_algorithm = PairingAlgorithm(pairing_algorithm)
+        assignment.rank_display_limit = params.get("assignment", None)
+        if assignment.rank_display_limit <= 0:
+            assignment.rank_display_limit = None
 
         criterion_ids = [c['id'] for c in params.criteria]
         if assignment.compared:
@@ -237,6 +241,9 @@ class AssignmentRootAPI(Resource):
         new_assignment.description = params.get("description")
         new_assignment.answer_start = dateutil.parser.parse(params.get('answer_start'))
         new_assignment.answer_end = dateutil.parser.parse(params.get('answer_end'))
+        new_assignment.rank_display_limit = params.get("rank_display_limit", None)
+        if new_assignment.rank_display_limit <= 0:
+            new_assignment.rank_display_limit = None
 
         new_assignment.compare_start = params.get('compare_start', None)
         if new_assignment.compare_start is not None:

--- a/acj/api/dataformat/__init__.py
+++ b/acj/api/dataformat/__init__.py
@@ -112,6 +112,7 @@ def get_assignment(restrict_user=True):
         'students_can_reply': fields.Boolean,
         'enable_self_evaluation': fields.Boolean,
         'pairing_algorithm': UnwrapPairingAlgorithm(attribute='pairing_algorithm'),
+        'rank_display_limit': fields.Integer(default=None),
 
         'compared': fields.Boolean,
 
@@ -277,11 +278,10 @@ def get_import_users_results(restrict_user=True):
 
 def get_score(restrict_user=True):
     ret = {
-        'criterion_id': fields.Integer
+        'criterion_id': fields.Integer,
+        'rank': fields.Integer
     }
-    if restrict_user:
-        ret['rank'] = fields.Integer
-    else:
+    if not restrict_user:
         ret['normalized_score'] = fields.Integer
 
     return ret

--- a/acj/models/assignment.py
+++ b/acj/models/assignment.py
@@ -34,6 +34,7 @@ class Assignment(DefaultTableMixin, ActiveMixin, WriteTrackingMixin):
         default=False, nullable=False)
     pairing_algorithm = db.Column(EnumType(PairingAlgorithm, name="pairing_algorithm"),
         nullable=True, default=PairingAlgorithm.random)
+    rank_display_limit = db.Column(db.Integer, nullable=True)
 
     # relationships
     # user via User Model

--- a/acj/models/score.py
+++ b/acj/models/score.py
@@ -68,25 +68,30 @@ class Score(DefaultTableMixin, WriteTrackingMixin):
     @hybrid_property
     def rank(self):
         scores = Score.get_assignment_scores(self.assignment_id, self.criterion_id)
-
         for index, score in enumerate(scores):
-            if score.normalized_score == self.normalized_score:
+            if score.score == self.score:
                 return index + 1
-
         return None
 
     # TODO: this should be cached
     @classmethod
     def get_assignment_scores(cls, assignment_id, criterion_id):
         return Score.query \
-            .with_entities(Score.normalized_score) \
-            .distinct() \
+            .with_entities(Score.score) \
             .filter(and_(
                 Score.assignment_id == assignment_id,
                 Score.criterion_id == criterion_id
             )) \
-            .order_by(Score.normalized_score.desc()) \
+            .order_by(Score.score.desc()) \
             .all()
+
+    @classmethod
+    def get_score_for_rank(cls, assignment_id, criterion_id, rank):
+        scores = Score.get_assignment_scores(assignment_id, criterion_id)
+        if len(scores) < rank:
+            return None
+        else:
+            return scores[rank-1].score
 
 
     @classmethod

--- a/acj/settings.py
+++ b/acj/settings.py
@@ -9,7 +9,7 @@ DATABASE = {
     'host': 'localhost',
     'port': '3306',
     'username': 'acj',
-    'password': 'acj',
+    'password': 'acjacj',
     'database': 'acj',
 }
 

--- a/acj/static/modules/assignment/assignment-form-partial.html
+++ b/acj/static/modules/assignment/assignment-form-partial.html
@@ -161,13 +161,13 @@
         </div>
 
         <hr />
-        
+
         <p>Add-on comparison options:</p>
-        
+
         <!-- TO DO: hook input into back end -->
         <input id="add_practice" type="checkbox" name="add_practice" ng-model="assignment.addPractice">
         <label for="add_practice">Start students with instructor-created answer pair for practice (before peer comparisons)</label>
-        
+
         <div ng-show="assignment.addPractice">
             <br />
             <div class="row">
@@ -175,7 +175,7 @@
                 <div class="col-md-5 form-group">
                     <!-- TO DO: make entry required if assignment.addPractice" -->
                     <label class="required-star">Answer A</label>
-                    &nbsp;&mdash;&nbsp; 
+                    &nbsp;&mdash;&nbsp;
                     <!-- TO DO: ng-if assignment has not yet been compared, create/pass actual data on click -->
                     <span><a href="" ng-click="changeAnswer('Answer A', answerID)">Edit</a></span>
                     <!-- TO DO: ng-if assignment has been compared -->
@@ -218,16 +218,16 @@
                     </div>
                 </div>
             </div>
-            
+
         </div>
-        
+
         <br />
-        
+
         <input id="enable_self_evaluation" type="checkbox" name="enable_self_evaluation" ng-model="assignment.enable_self_evaluation">
         <label for="enable_self_evaluation">Require that students also evaluate their own answer (after peer comparisons)</label>
-        
+
         <hr />
-        
+
             <a href="" ng-click="showAdvanced = !showAdvanced">
                 <p>
                     <i class="fa fa-chevron-down" ng-show="showAdvanced"></i>
@@ -241,7 +241,7 @@
                     <div class="form-check col-md-1"></div>
                     <div class="form-check col-md-5">
                         <label class="form-check-label">
-                            <input class="form-check-input" type="radio" ng-model="assignment.pairing_algorithm" value="random" checked>
+                            <input class="form-check-input" type="radio" ng-model="assignment.pairing_algorithm" value="{{PairingAlgorithm.random}}">
                             Randomly select answers for comparison (no scores/rank):
                         </label>
                         <ul>
@@ -253,7 +253,7 @@
                     <div class="form-check col-md-1"></div>
                     <div class="form-check col-md-5">
                         <label class="form-check-label">
-                            <input class="form-check-input" type="radio" ng-model="assignment.pairing_algorithm" value="adaptive">
+                            <input class="form-check-input" type="radio" ng-model="assignment.pairing_algorithm" value="{{PairingAlgorithm.adaptive}}">
                             Adaptively select answers for comparison (add scores/rank):
                         </label>
                         <ul>

--- a/acj/static/modules/assignment/assignment-module.js
+++ b/acj/static/modules/assignment/assignment-module.js
@@ -307,13 +307,14 @@ module.filter("notScoredEnd", function () {
 module.controller("AssignmentViewController",
     ["$scope", "$log", "$routeParams", "$location", "AnswerResource", "Authorize", "AssignmentResource", "AssignmentCommentResource",
              "AttachmentResource", "ComparisonResource", "CourseResource", "required_rounds", "Session", "Toaster", "AnswerCommentResource",
-             "GroupResource", "AnswerCommentType",
+             "GroupResource", "AnswerCommentType", "PairingAlgorithm",
     function($scope, $log, $routeParams, $location, AnswerResource, Authorize, AssignmentResource, AssignmentCommentResource,
              AttachmentResource, ComparisonResource, CourseResource, required_rounds, Session, Toaster, AnswerCommentResource,
-             GroupResource, AnswerCommentType)
+             GroupResource, AnswerCommentType, PairingAlgorithm)
     {
         $scope.courseId = $routeParams['courseId'];
         $scope.AnswerCommentType = AnswerCommentType;
+        $scope.PairingAlgorithm = PairingAlgorithm;
         var assignmentId = $scope.assignmentId = $routeParams['assignmentId'];
         var params = {
             courseId: $scope.courseId,
@@ -330,7 +331,7 @@ module.controller("AssignmentViewController",
             orderBy: null
         };
         $scope.self_evaluation_needed = false;
-        $scope.rankLimit = 10; //default is top 10 answers
+        $scope.rankLimit = null;
 
         Session.getUser().then(function(user) {
             $scope.loggedInUserId = user.id;
@@ -345,10 +346,9 @@ module.controller("AssignmentViewController",
 
                     $scope.criteria = ret.criteria;
                     $scope.reverse = true;
-                    
-                    if (ret.rank_limit) {
-                        $scope.rankLimit = ret.rank_limit;
-                    }
+
+                    // rank_display_limit is null, 10, or 20
+                    $scope.rankLimit = ret.rank_display_limit;
 
                     $scope.readDate = Date.parse(ret.created);
 
@@ -619,6 +619,7 @@ module.controller("AssignmentWriteController",
         $scope.assignment = {criteria: []};
         $scope.availableCriteria = [];
         $scope.editorOptions = EditorOptions.basic;
+        $scope.PairingAlgorithm = PairingAlgorithm;
 
         $scope.uploader = attachService.getUploader();
         $scope.resetName = attachService.resetName();
@@ -647,6 +648,7 @@ module.controller("AssignmentWriteController",
             // default the setting to the recommended # of comparisons
             $scope.assignment.number_of_comparisons = $scope.recommended_comparisons;
             $scope.assignment.pairing_algorithm = PairingAlgorithm.random;
+            $scope.assignment.rank_display_limit = 10;
 
             $scope.date.astart.date.setDate(today.getDate()+1);
             $scope.date.aend.date.setDate(today.getDate()+8);

--- a/acj/static/modules/assignment/assignment-module_spec.js
+++ b/acj/static/modules/assignment/assignment-module_spec.js
@@ -135,7 +135,8 @@ describe('course-module', function () {
             "id": 1
         },
         "user_id": 1,
-        "pairing_algorithm": "random"
+        "pairing_algorithm": "random",
+        "rank_display_limit": 10
     };
 
     var mockStudents = {
@@ -929,7 +930,8 @@ describe('course-module', function () {
                     criteria: [defaultCriteria],
                     students_can_reply: false,
                     number_of_comparisons: 3,
-                    pairing_algorithm: 'random'
+                    pairing_algorithm: 'random',
+                    rank_display_limit: 10
                 });
                 expect($rootScope.recommended_comparisons).toEqual(3);
                 expect($rootScope.availableCriteria).toEqual(otherCriteria);

--- a/acj/static/modules/assignment/assignment-view-partial.html
+++ b/acj/static/modules/assignment/assignment-view-partial.html
@@ -147,7 +147,7 @@
                                     <option value="">All answers</option>
                                 </select>
                             </span><br />
-                            <span class="filter" ng-if="rankLimit > 0 && assignment.pairing_algorithm != 'random'">
+                            <span class="filter" ng-if="rankLimit && assignment.pairing_algorithm != PairingAlgorithm.random">
                                 <label>Order by: &nbsp;</label>
                                 <select ng-model="answerFilters.orderBy"
                                         ng-options="c.id as c.name for c in criteria">
@@ -226,7 +226,7 @@
                             pdf="answer.file">
                         </acj-pdf-inline>
                     </div>
-                    
+
                     <p class="pull-right">
                         <em>{{instructors[answer.user_id]}} Response</em>
                     </p>
@@ -281,7 +281,7 @@
                         <em ng-if="score.rank <= rankLimit">
                             Students Ranked: <strong>{{score.rank}} <span ng-if="rankCount[score.rank] > 1">(tied)</span></strong>
                         </em>
-                        <em ng-if="score.rank > 0 && score.rank >= rankLimit">
+                        <em ng-if="score.rank > 0 && score.rank > rankLimit">
                             Not in Top {{rankLimit}}
                         </em>
                     </p>
@@ -460,7 +460,7 @@
                     <acj-avatar user-id="comparison_set.user_id" avatar="comparison_set.user.avatar" me="true"></acj-avatar>
                     <strong>compared</strong> on {{ comparison_set.created | amDateFormat: 'MMM D @ h:mm a'}}:
                 </div>
-                
+
                 <!-- Answers -->
                 <h5 class="content">Answer Pair</h5>
                     <p class="show-answers content"><a href="" ng-click="showAnswers = !showAnswers;">
@@ -472,7 +472,7 @@
                         <acj-answer-content answer="comparison_set.answer1" is-chosen="comparison.winner_id == comparison_set.answer1_id" name="Odd-Numbered Answer" criterion="comparison.criterion_id" show-score="false"></acj-answer-content>
                         <acj-answer-content answer="comparison_set.answer2" is-chosen="comparison.winner_id == comparison_set.answer2_id" name="Even-Numbered Answer" criterion="comparison.criterion_id" show-score="false"></acj-answer-content>
                     </div>
-                    
+
                 <div class="row">
                     <div class="col-md-6">
                         <h5 class="content">Feedback for Odd-Numbered Answer</h5>
@@ -481,7 +481,7 @@
                             <div class="content" mathjax hljs ng-bind-html="feedback.content"></div>
                         </div>
                     </div>
-    
+
                     <div class="col-md-6">
                         <h5 class="content">Feedback for Even-Numbered Answer</h5>
                         <!-- feedback for even-numbered answer -->
@@ -490,7 +490,7 @@
                         </div>
                     </div>
                 </div>
-                    
+
                 <h5 class="content">Comparisons</h5>
                 <div ng-repeat="comparison in comparison_set.comparisons">
                     <div class="content">

--- a/acj/static/modules/comparison/comparison-module_spec.js
+++ b/acj/static/modules/comparison/comparison-module_spec.js
@@ -146,6 +146,7 @@ describe('comparison-module', function () {
             },
             "enable_self_evaluation": true,
             "pairing_algorithm": "random",
+            "rank_display_limit": 10,
             "name": "Read the poem below, and make notes on syntax, figurative language, patterns of diction and imagery, and form. Then, imagining that you are writing a 1200-word essay, write a critical premise of 20-60 words as we have discussed in class."
         };
 

--- a/acj/static/test/factories/assignment_factory.js
+++ b/acj/static/test/factories/assignment_factory.js
@@ -11,6 +11,7 @@ var assignmentTemplate = {
     "after_comparing": false,
     "enable_self_evaluation": false,
     "pairing_algorithm": "random",
+    "rank_display_limit": 10,
     "comment_count": 0,
     "evaluation_count": 0,
     "answer_count": 0,

--- a/acj/static/test/factories/http_backend_mocks.js
+++ b/acj/static/test/factories/http_backend_mocks.js
@@ -529,6 +529,7 @@ module.exports.httpbackendMock = function(storageFixture) {
                 "file": [],
                 "user": angular.copy(currentUser),
                 "pairing_algorithm": null,
+                "rank_display_limit": null
             }
             newAssignment = angular.merge(newAssignment, data);
             newAssignment.id = storage.assignments.length + 1;

--- a/alembic/versions/17b7bd2e218c_add_rank_limit_to_assignment.py
+++ b/alembic/versions/17b7bd2e218c_add_rank_limit_to_assignment.py
@@ -1,0 +1,23 @@
+"""Add rank_limit to assignment
+
+Revision ID: 17b7bd2e218c
+Revises: 3f27a2b13b82
+Create Date: 2016-08-10 12:39:04.501928
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '17b7bd2e218c'
+down_revision = '3f27a2b13b82'
+
+from alembic import op
+import sqlalchemy as sa
+
+from acj.models import convention
+
+def upgrade():
+    op.add_column('assignment', sa.Column('rank_display_limit', sa.Integer(), nullable=True))
+
+def downgrade():
+    with op.batch_alter_table('assignment', naming_convention=convention) as batch_op:
+        batch_op.drop_column('rank_display_limit')

--- a/data/factories.py
+++ b/data/factories.py
@@ -73,6 +73,7 @@ class AssignmentFactory(SQLAlchemyModelFactory):
     compare_start = None
     compare_end = None
     number_of_comparisons = 3
+    rank_display_limit = 10
     # Make sure created dates are unique.
     created = factory.Sequence(lambda n: datetime.datetime.fromtimestamp(1404768528 - n))
 


### PR DESCRIPTION
answers list endpoint will no longer include answers without a score when sorting by criterion scores
answers list endpoint will only include answers within the rank_display_limit for students (if rank_display_limit is null, it will return all answers). Instructors and teaching assistants are not effected by this.