### PR TITLE
Add multi-user class list actions

### DIFF
--- a/acj/api/__init__.py
+++ b/acj/api/__init__.py
@@ -20,7 +20,7 @@ def register_api_blueprints(app):
     from .course_group_user import course_group_user_api
     app.register_blueprint(
         course_group_user_api,
-        url_prefix='/api/courses/<int:course_id>/users/<int:user_id>/groups')
+        url_prefix='/api/courses/<int:course_id>/users')
 
     from .login import login_api
     app.register_blueprint(login_api)
@@ -190,7 +190,8 @@ def log_events(log):
 
     # classlist events
     from .classlist import on_classlist_get, on_classlist_upload, on_classlist_enrol, on_classlist_unenrol, \
-        on_classlist_instructor_label, on_classlist_instructor, on_classlist_student
+        on_classlist_instructor_label, on_classlist_instructor, on_classlist_student, \
+        on_classlist_update_users_course_roles
     on_classlist_get.connect(log)
     on_classlist_upload.connect(log)
     on_classlist_enrol.connect(log)
@@ -198,6 +199,7 @@ def log_events(log):
     on_classlist_instructor_label.connect(log)
     on_classlist_instructor.connect(log)
     on_classlist_student.connect(log)
+    on_classlist_update_users_course_roles.connect(log)
 
     # course group events
     from .course_group import on_course_group_get, on_course_group_import, on_course_group_members_get
@@ -206,9 +208,12 @@ def log_events(log):
     on_course_group_members_get.connect(log)
 
     # course user group events
-    from .course_group_user import on_course_group_user_create, on_course_group_user_delete
+    from .course_group_user import on_course_group_user_create, on_course_group_user_delete, \
+        on_course_group_user_list_create, on_course_group_user_list_delete
     on_course_group_user_create.connect(log)
     on_course_group_user_delete.connect(log)
+    on_course_group_user_list_create.connect(log)
+    on_course_group_user_list_delete.connect(log)
 
     # report event
     from .report import on_export_report

--- a/acj/api/course_group_user.py
+++ b/acj/api/course_group_user.py
@@ -14,13 +14,18 @@ from acj.core import db, event
 from acj.models import UserCourse, User, Course, CourseRole
 from .util import new_restful_api
 
+user_list_parser = RequestParser()
+user_list_parser.add_argument('ids', type=list, required=True, default=[], location='json')
+
 course_group_user_api = Blueprint('course_group_user_api', __name__)
 api = new_restful_api(course_group_user_api)
 
 on_course_group_user_create = event.signal('COURSE_GROUP_USER_CREATE')
+on_course_group_user_list_create = event.signal('COURSE_GROUP_USER_LIST_CREATE')
 on_course_group_user_delete = event.signal('COURSE_GROUP_USER_DELETE')
+on_course_group_user_list_delete = event.signal('COURSE_GROUP_USER_LIST_CREATE')
 
-# /users/:user_id/groups/:group_name
+# /:user_id/groups/:group_name
 class GroupUserIdAPI(Resource):
     @login_required
     def post(self, course_id, user_id, group_name):
@@ -49,9 +54,9 @@ class GroupUserIdAPI(Resource):
             data={'user_id': user_id})
 
         return {'group_name': group_name}
-api.add_resource(GroupUserIdAPI, '/<group_name>')
+api.add_resource(GroupUserIdAPI, '/<int:user_id>/groups/<group_name>')
 
-# /users/:user_id/groups
+# /:user_id/groups
 class GroupUserAPI(Resource):
     @login_required
     def delete(self, course_id, user_id):
@@ -77,4 +82,82 @@ class GroupUserAPI(Resource):
             data={'user_id': user_id})
 
         return {'user_id': user_id, 'course_id': course_id}
-api.add_resource(GroupUserAPI, '')
+api.add_resource(GroupUserAPI, '/<int:user_id>/groups')
+
+
+# /groups/:group_name
+class GroupUserListGroupNameAPI(Resource):
+    @login_required
+    def post(self, course_id, group_name):
+        Course.get_active_or_404(course_id)
+        require(EDIT, UserCourse(course_id=course_id))
+
+        params = user_list_parser.parse_args()
+
+        if len(params.get('ids')) == 0:
+            return {"error": "Must have at least one user id"}, 400
+
+        user_courses = UserCourse.query \
+            .filter(and_(
+                UserCourse.course_id == course_id,
+                UserCourse.user_id.in_(params.get('ids')),
+                UserCourse.course_role != CourseRole.dropped
+            )) \
+            .all()
+
+        if len(params.get('ids')) != len(user_courses):
+            return {"error": "One or more users are not enrolled in the course"}, 400
+
+        for user_course in user_courses:
+            user_course.group_name = group_name
+
+        db.session.commit()
+
+        on_course_group_user_list_create.send(
+            current_app._get_current_object(),
+            event_name=on_course_group_user_list_create.name,
+            user=current_user,
+            course_id=course_id,
+            data={'user_ids': params.get('ids')})
+
+        return {'group_name': group_name}
+
+api.add_resource(GroupUserListGroupNameAPI, '/groups/<group_name>')
+
+class GroupUserListAPI(Resource):
+    @login_required
+    def post(self, course_id):
+        Course.get_active_or_404(course_id)
+        require(EDIT, UserCourse(course_id=course_id))
+
+        params = user_list_parser.parse_args()
+
+        if len(params.get('ids')) == 0:
+            return {"error": "Must have at least one user id"}, 400
+
+        user_courses = UserCourse.query \
+            .filter(and_(
+                UserCourse.course_id == course_id,
+                UserCourse.user_id.in_(params.get('ids')),
+                UserCourse.course_role != CourseRole.dropped
+            )) \
+            .all()
+
+        if len(params.get('ids')) != len(user_courses):
+            return {"error": "One or more users are not enrolled in the course"}, 400
+
+        for user_course in user_courses:
+            user_course.group_name = None
+
+        db.session.commit()
+
+        on_course_group_user_list_delete.send(
+            current_app._get_current_object(),
+            event_name=on_course_group_user_list_delete.name,
+            user=current_user,
+            course_id=course_id,
+            data={'user_ids': params.get('ids')})
+
+        return {'course_id': course_id}
+
+api.add_resource(GroupUserListAPI, '/groups')

--- a/acj/static/modules/classlist/classlist-view-partial.html
+++ b/acj/static/modules/classlist/classlist-view-partial.html
@@ -40,7 +40,8 @@
     <div class="table-responsive">
         <table class="table table-striped">
             <thead>
-                <tr class>
+                <tr>
+                    <th></th>
                     <th>Actions</th>
                     <th>
                         <a href="" ng-click="reverse = predicate == 'firstname' && !reverse; predicate = 'firstname'">
@@ -70,7 +71,10 @@
                 </tr>
             </thead>
             <tbody>
-                <tr ng-repeat="user in classlist | orderBy:predicate:reverse">
+                <tr ng-class="{'success': user.selected}" ng-repeat="user in classlist | orderBy:predicate:reverse">
+                    <td>
+                        <input ng-click="user.selected = !user.selected" type="checkbox" ng-checked="user.selected">
+                    </td>
                     <td>
                         <a href="#/user/{{user.id}}/edit" target="_blank">
                             Edit
@@ -101,5 +105,46 @@
             </tbody>
         </table>
     </div>
+    <div ng-show="classlist.length > 0">
+        <hr>
+        <label>Add Selected Users to Group</label>
+        <div class="row">
+            <div class="col-sm-2">
+                <p><a id="add-new-group" href="" class="btn btn-small btn-primary" ng-click="addUsersToNewGroup()">Add New</a></p>
+            </div>
+            <div class="col-sm-1">
+                <p>OR</p>
+            </div>
+            <div class="form-group col-sm-6">
+                <select id="select-group" class="form-control" ng-model="selectedGroup"
+                        ng-options="g as g for g in groups">
+                    <option value="">- None -</option>
+                </select>
+            </div>
+            <div class="col-sm-3">
+                <p><a id="add-select-group" class="btn btn-small btn-primary" ng-click="addUsersToGroup(selectedGroup)"
+                      ng-disabled="!groups.length">Update Group</a></p>
+            </div>
+        </div>
 
+        <label>Update Enrolment Status for Selected Users</label>
+        <div class="row">
+            <div class="col-sm-2">
+                <p><a id="drop-users" href="" class="btn btn-small btn-danger" ng-click="updateUsers()">Drop</a></p>
+            </div>
+            <div class="col-sm-1">
+                <p>OR</p>
+            </div>
+            <div class="form-group col-sm-6">
+                <select id="select-group" class="form-control" ng-model="selectedCourseRole"
+                        ng-options="course_role as course_role for course_role in course_roles">
+                    <option value="">- select a role -</option>
+                </select>
+            </div>
+            <div class="col-sm-3">
+                <p><a id="add-select-group" class="btn btn-small btn-primary" ng-click="updateUsers(selectedCourseRole)"
+                      ng-disabled="!selectedCourseRole">Update Course Role</a></p>
+            </div>
+        </div>
+    </div>
 </div>

--- a/acj/static/modules/group/group-form-partial.html
+++ b/acj/static/modules/group/group-form-partial.html
@@ -1,0 +1,14 @@
+<p class="pull-right"><a href="" ng-click="cancel()">Cancel</a></p>
+<h1>Add Group</h1>
+<br />
+<ng-form name="groupForm" class="form">
+    <acj-field-with-feedback form-control="groupForm.groupName">
+        <label class="required-star" for="criterionName">Group Name</label>
+        <input type="text" maxlength="255" ng-model="group.name" id="groupName" name="groupName" class="form-control" required/>
+    </acj-field-with-feedback>
+    <div class="text-center">
+        <input type="button" ng-click="groupSubmit()" class="btn btn-success btn-lg" value="Add New"
+        ng-disabled="groupForm.$invalid" />
+    </div>
+    <br />
+</ng-form>

--- a/acj/static/modules/group/group-module.js
+++ b/acj/static/modules/group/group-module.js
@@ -9,7 +9,8 @@ var module = angular.module('ubc.ctlt.acj.group',
         'ubc.ctlt.acj.attachment',
         'ubc.ctlt.acj.common.form',
         'ubc.ctlt.acj.common.interceptor',
-        'ubc.ctlt.acj.toaster'
+        'ubc.ctlt.acj.toaster',
+        'ui.bootstrap'
     ]
 );
 
@@ -23,6 +24,8 @@ module.factory(
         var unenrolUrl = '/api/courses/:courseId/users/:userId/groups';
         var ret = $resource(url, {groupName: '@groupName'},
             {
+                updateUsersGroup: {method: 'POST', url: '/api/courses/:courseId/users/groups/:groupName', interceptor: Interceptors.enrolCache},
+                removeUsersGroup: {method: 'POST', url: '/api/courses/:courseId/users/groups', interceptor: Interceptors.enrolCache},
                 enrol: {method: 'POST', url: unenrolUrl+'/:groupName', interceptor: Interceptors.enrolCache},
                 unenrol: {method: 'DELETE', url: unenrolUrl, interceptor: Interceptors.enrolCache}
             }
@@ -85,6 +88,22 @@ module.controller(
 
         // TODO: change "Row" to something more meaningful
         $scope.headers = ['Row', 'Message'];
+    }
+]);
+
+module.controller(
+    'AddGroupModalController',
+    ["$rootScope", "$scope", "$modalInstance",
+    function ($rootScope, $scope, $modalInstance) {
+        $scope.group = {};
+
+        $scope.cancel = function (ret) {
+            $modalInstance.close();
+        }
+
+        $scope.groupSubmit = function () {
+            $modalInstance.close($scope.group.name);
+        };
     }
 ]);
 


### PR DESCRIPTION
Mange users screen now has multi-user actions for:
- adding to a new group, existing groups, or no group
- updating existing users course roles (includes dropped)

UI needs to be reviewed

Related #282 