### PR TITLE
Allow all course users to do comparisons

### DIFF
--- a/acj/authorization.py
+++ b/acj/authorization.py
@@ -72,6 +72,8 @@ def define_authorization(user, they):
         they.can(CREATE, AnswerComment, course_id=entry.course_id)
         # owner of the answer comment
         they.can((EDIT, DELETE, READ), AnswerComment, user_id=user.id)
+        # students, instructor and ta can submit comparisons
+        they.can(CREATE, Comparison, course_id=entry.course_id)
         # instructors can modify the course and enrolment
         if entry.course_role == CourseRole.instructor:
             they.can(EDIT, Course, id=entry.course_id)
@@ -90,9 +92,6 @@ def define_authorization(user, they):
             they.can(READ, USER_IDENTITY)
             # TA can create criteria
             they.can(CREATE, Criterion)
-        # only students can submit comparisons for now
-        if entry.course_role == CourseRole.student:
-            they.can(CREATE, Comparison, course_id=entry.course_id)
 
 
 # Tell the client side about a user's permissions.

--- a/acj/static/modules/assignment/assignment-view-partial.html
+++ b/acj/static/modules/assignment/assignment-view-partial.html
@@ -87,6 +87,12 @@
             Compare Answers
         </a>
 
+        <!-- BUTTON when user is an admin AND (the comparison period is active) -->
+        <a class="btn" ng-class="{'btn-success': assignment.status.comparisons.available, 'btn-default': !assignment.status.comparisons.available}" title="Compare Answers" ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/compare"
+           ng-show="canManageAssignment && assignment.compare_period">
+            Compare Answers
+        </a>
+
         <!-- BUTTON when user is an admin AND (the comparison period is active OR is complete) -->
         <a class="btn btn-success" title="Comparisons" ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/comparisons"
            ng-show="canManageAssignment && (assignment.compare_period || assignment.after_comparing)">

--- a/acj/static/modules/comparison/comparison-core.html
+++ b/acj/static/modules/comparison/comparison-core.html
@@ -36,7 +36,9 @@
         </div>
 
         <h2 class="col-md-6">Answer Pair</h2>
-        <h2 class="col-md-6 text-right rounds"><span ng-hide="comparisonsError" class="label label-warning">Round {{current}} / {{total}}</span></h2>
+        <h2 class="col-md-6 text-right rounds"><span ng-hide="comparisonsError" class="label label-warning">
+            Round {{current}} <span ng-if="!canManageAssignment">/ {{total}}</span>
+        </h2>
 
         <div ng-show="comparisonsError" class="alert alert-info" role="alert">
             <p><strong>Break time!</strong> You've compared the currently available answer pairs. Please check back later to compare new pairs after more answers have been submitted.</p>

--- a/acj/static/modules/comparison/comparison-module_spec.js
+++ b/acj/static/modules/comparison/comparison-module_spec.js
@@ -442,6 +442,8 @@ describe('comparison-module', function () {
                 $httpBackend.expectPOST('/api/courses/3abcABC123-abcABC123_Z/assignments/9abcABC123-abcABC123_Z/answers/407cABC123-abcABC123_Z/comments', expectedAnswerComment1).respond({});
                 $httpBackend.expectPOST('/api/courses/3abcABC123-abcABC123_Z/assignments/9abcABC123-abcABC123_Z/answers/279cABC123-abcABC123_Z/comments/3703ABC123-abcABC123_Z', expectedAnswerComment2).respond({});
                 $httpBackend.expectPOST('/api/courses/3abcABC123-abcABC123_Z/assignments/9abcABC123-abcABC123_Z/comparisons', expectedComparison).respond(mockComparisonResponse);
+				// users with management permissions do not reload the assignment status at this point anymore
+                /*
                 $httpBackend.expectGET('/api/courses/3abcABC123-abcABC123_Z/assignments/9abcABC123-abcABC123_Z/status').respond({
                     "status": {
                         "answers": {
@@ -457,6 +459,7 @@ describe('comparison-module', function () {
                         }
                     }
                 });
+                */
 
                 expect($rootScope.preventExit).toBe(true);
 

--- a/acj/static/modules/course/course-assignments-partial.html
+++ b/acj/static/modules/course/course-assignments-partial.html
@@ -52,7 +52,7 @@
 
     <!-- Assignments List -->
     <div class="row each-assignment" ng-class="{'first-child': $first}"
-        ng-repeat="(key, assignment) in assignments | filter:assignmentFilter(filter) as results">
+        ng-repeat="assignment in assignments | filter:assignmentFilter(filter) as results">
 
         <!-- Assignment Display -->
         <div class="col-sm-9 media">
@@ -126,7 +126,7 @@
                         <span ng-if="!assignment.answer_period">Students answer<span ng-if="assignment.available">ed</span> {{assignment.answer_start | amDateFormat: 'MMM D'}}-{{assignment.answer_end | amDateFormat: 'MMM D'}}</span>
                     </li>
                     <li ng-if="canManageAssignment || assignment.user_id == loggedInUserId">
-                        <a confirmation-needed="deleteAssignment(key, course.id, assignment.id)" keyword="assignment" title="Delete" href="">
+                        <a confirmation-needed="deleteAssignment(course.id, assignment.id)" keyword="assignment" title="Delete" href="">
                             <i class="fa fa-trash-o"></i>
                         </a>
                     </li>
@@ -141,13 +141,13 @@
 
             <!-- BUTTON when user does not have an answer draft AND (user is admin OR (user has not answered AND the answer period is active) -->
             <a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/answer/create" class="btn btn-success" title="Answer Assignment"
-            ng-show="!assignment.status.answers.has_draft && (canManageAssignment || (!assignment.status.answers.answered && assignment.answer_period))">
+               ng-show="!assignment.status.answers.has_draft && (canManageAssignment || (!assignment.status.answers.answered && assignment.answer_period))">
                 Answer
             </a>
 
             <!-- BUTTON when user has an answer draft AND (user is admin OR (user has not answered AND the answer period is active) -->
             <a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/answer/{{assignment.status.answers.draft_ids[0]}}/edit" class="btn btn-success" title="Answer Assignment"
-            ng-show="assignment.status.answers.has_draft && (canManageAssignment || (!assignment.status.answers.answered && assignment.answer_period))">
+               ng-show="assignment.status.answers.has_draft && (canManageAssignment || (!assignment.status.answers.answered && assignment.answer_period))">
                 Finish Answer
             </a>
 
@@ -165,6 +165,12 @@
                  enabled only when user has answered assignment -->
             <a class="btn" ng-class="{'btn-success': assignment.status.answers.answered, 'btn-default': !assignment.status.answers.answered}" title="Compare Answers" ng-href="#/course/{{ course.id }}/assignment/{{ assignment.id }}/self_evaluation"
                ng-show="!canManageAssignment && assignment.compare_period && !assignment.comparisons_left > 0 && assignment.self_evaluation_needed && ((assignment.answer_period && assignment.status.answers.answered) || (!assignment.answer_period))" ng-disabled="!assignment.status.answers.answered">
+                Compare Answers
+            </a>
+
+            <!-- BUTTON when user is an admin AND (the comparison period is active) -->
+            <a class="btn" ng-class="{'btn-success': assignment.status.comparisons.available, 'btn-default': !assignment.status.comparisons.available}" title="Compare Answers" ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/compare"
+               ng-show="canManageAssignment && assignment.compare_period">
                 Compare Answers
             </a>
 

--- a/acj/static/modules/course/course-module.js
+++ b/acj/static/modules/course/course-module.js
@@ -131,11 +131,13 @@ module.controller(
             }
         );
 
-        $scope.deleteAssignment = function(key, course_id, assignment_id) {
+        $scope.deleteAssignment = function(course_id, assignment_id) {
             AssignmentResource.delete({'courseId': course_id, 'assignmentId': assignment_id}).$promise.then(
                 function (ret) {
-                    $scope.assignments.splice(key, 1);
                     Toaster.success("Successfully deleted assignment " + ret.id);
+                    $scope.assignments = _.filter($scope.assignments, function(assignment) {
+                        return assignment.id != assignment_id;
+                    });
                 },
                 function (ret) {
                     Toaster.reqerror("Assignment deletion failed", ret);

--- a/acj/static/test/features/step_definitions/edit_assignment.js
+++ b/acj/static/test/features/step_definitions/edit_assignment.js
@@ -51,7 +51,7 @@ var editAssignmentStepDefinitionsWrapper = function () {
     });
 
     this.Then("I should see the assignment with the new name and description", function() {
-        var item = element.all(by.repeater("(key, assignment) in assignments | filter:assignmentFilter(filter) as results")).get(2)
+        var item = element.all(by.repeater("assignment in assignments | filter:assignmentFilter(filter) as results")).get(2)
 
         expect(item.element(by.css(".media-heading")).getText()).to.eventually.equal("New Name »");
         return expect(item.element(by.css(".assignment-desc p")).getText()).to.eventually.equal("This is the new description");

--- a/acj/tests/api/test_assignment.py
+++ b/acj/tests/api/test_assignment.py
@@ -289,7 +289,7 @@ class AssignmentEditComparedAPITests(ACJAPITestCase):
 
         for comparison_example in self.data.comparisons_examples:
             if comparison_example.assignment_id == self.assignment.id:
-                comparisons = Comparison.create_new_comparison_set(self.assignment.id, user_id)
+                comparisons = Comparison.create_new_comparison_set(self.assignment.id, user_id, False)
                 self.assertEqual(comparisons[0].answer1_id, comparison_example.answer1_id)
                 self.assertEqual(comparisons[0].answer2_id, comparison_example.answer2_id)
                 for comparison in comparisons:
@@ -308,7 +308,7 @@ class AssignmentEditComparedAPITests(ACJAPITestCase):
         # n - 1 possible pairs before all answers have been compared
         num_possible_comparisons = num_eligible_answers - 1
         for i in range(num_possible_comparisons):
-            comparisons = Comparison.create_new_comparison_set(self.assignment.id, user_id)
+            comparisons = Comparison.create_new_comparison_set(self.assignment.id, user_id, False)
             for comparison in comparisons:
                 comparison.completed = True
                 comparison.winner_id = min([comparisons[0].answer1_id, comparisons[0].answer2_id])
@@ -381,7 +381,7 @@ class AssignmentStatusComparisonsAPITests(ACJAPITestCase):
 
         for comparison_example in self.data.comparisons_examples:
             if comparison_example.assignment_id == self.assignment.id:
-                comparisons = Comparison.create_new_comparison_set(self.assignment.id, user_id)
+                comparisons = Comparison.create_new_comparison_set(self.assignment.id, user_id, False)
                 self.assertEqual(comparisons[0].answer1_id, comparison_example.answer1_id)
                 self.assertEqual(comparisons[0].answer2_id, comparison_example.answer2_id)
                 for comparison in comparisons:
@@ -400,7 +400,7 @@ class AssignmentStatusComparisonsAPITests(ACJAPITestCase):
         # n - 1 possible pairs before all answers have been compared
         num_possible_comparisons = num_eligible_answers - 1
         for i in range(num_possible_comparisons):
-            comparisons = Comparison.create_new_comparison_set(self.assignment.id, user_id)
+            comparisons = Comparison.create_new_comparison_set(self.assignment.id, user_id, False)
             for comparison in comparisons:
                 comparison.completed = True
                 comparison.winner_id = min([comparisons[0].answer1_id, comparisons[0].answer2_id])

--- a/data/fixtures/test_data.py
+++ b/data/fixtures/test_data.py
@@ -536,7 +536,7 @@ class TestFixture:
         for assignment in self.assignments:
             for student in self.students:
                 for i in range(assignment.total_comparisons_required):
-                    comparisons = Comparison.create_new_comparison_set(assignment.id, student.id)
+                    comparisons = Comparison.create_new_comparison_set(assignment.id, student.id, False)
                     for comparison in comparisons:
                         comparison.completed = True
                         comparison.winner_id = min([comparisons[0].answer1_id, comparisons[0].answer2_id])


### PR DESCRIPTION
Allows all users with management access to an assignment (instructors, teaching assistants and system admins) to perform comparisons. These users are not stopped from continuing to perform comparisons when completing more than assignments assigned number of comparisons. They also do not see the comparison example if it is set.

Resolves #380