### PR TITLE
Modify classlist import

### DIFF
--- a/acj/api/classlist.py
+++ b/acj/api/classlist.py
@@ -158,7 +158,7 @@ def import_users(import_type, course, users):
             u.password = None
         else:
             # ComPAIR login
-            u.password = user[PASSWORD] if length > PASSWORD and user[PASSWORD] else random_generator(16, letters_digits)
+            u.password = user[PASSWORD] if length > PASSWORD and user[PASSWORD] else None
 
         # validate student number (if not None)
         if u.student_number:

--- a/acj/models/user.py
+++ b/acj/models/user.py
@@ -118,8 +118,8 @@ class User(DefaultTableMixin, UUIDMixin, WriteTrackingMixin, UserMixin):
 
     @hybrid_property
     def uses_acj_login(self):
-        # third party auth users may have their username and password not set
-        return self.username != None and self.password != None
+        # third party auth users may have their username not set
+        return self.username != None
 
     def verify_password(self, password):
         if self.password == None:


### PR DESCRIPTION
Set password to null if none is given (speeds up imports)
Modified the conditions for hiding the ComPAIR account login information to only when username is null (so that system admins can update passwords for users who have been imported with a password of null)

Related #374